### PR TITLE
fix: replace hard-coded genesisHash with prevBlockHash/prevStateRoot

### DIFF
--- a/execution/evm/execution.go
+++ b/execution/evm/execution.go
@@ -250,7 +250,7 @@ func (c *EngineClient) ExecuteTxs(ctx context.Context, txs [][]byte, blockHeight
 	err = c.engineClient.CallContext(ctx, &newPayloadResult, "engine_newPayloadV4",
 		payloadResult.ExecutionPayload,
 		[]string{}, // No blob hashes
-		prevBlockHash.Hex(),
+		c.genesisHash.Hex(),
 		[][]byte{}, // No execution requests
 	)
 	if err != nil {

--- a/execution/evm/execution.go
+++ b/execution/evm/execution.go
@@ -211,6 +211,7 @@ func (c *EngineClient) ExecuteTxs(ctx context.Context, txs [][]byte, blockHeight
 		ts = prevTimestamp + 1 // Subsequent blocks must have a higher timestamp.
 	}
 
+    parentStateRoot := common.BytesToHash(prevStateRoot)
 	// update forkchoice to get the next payload id
 	var forkchoiceResult engine.ForkChoiceResponse
 	err = c.engineClient.CallContext(ctx, &forkchoiceResult, "engine_forkchoiceUpdatedV3",
@@ -224,7 +225,7 @@ func (c *EngineClient) ExecuteTxs(ctx context.Context, txs [][]byte, blockHeight
 			Random:                prevBlockHash, //c.derivePrevRandao(height),
 			SuggestedFeeRecipient: c.feeRecipient,
 			Withdrawals:           []*types.Withdrawal{},
-			BeaconRoot:            &c.genesisHash,
+			BeaconRoot:            &parentStateRoot,
 			Transactions:          txsPayload,
 			NoTxPool:              true,
 		},
@@ -249,7 +250,7 @@ func (c *EngineClient) ExecuteTxs(ctx context.Context, txs [][]byte, blockHeight
 	err = c.engineClient.CallContext(ctx, &newPayloadResult, "engine_newPayloadV4",
 		payloadResult.ExecutionPayload,
 		[]string{}, // No blob hashes
-		c.genesisHash.Hex(),
+		prevBlockHash.Hex(),
 		[][]byte{}, // No execution requests
 	)
 	if err != nil {


### PR DESCRIPTION
## fix(evm-executor): replace hard-coded genesisHash with prevBlockHash/prevStateRoot

**Overview**

This PR fixes a critical bug in the EVM executor where every block after height 1 was still referencing `genesisHash` as its parent/state root. We now pass the actual `prevBlockHash` and `prevStateRoot` supplied by Rollkit, ensuring headers chain correctly and the Rollkit chain advances beyond the first block. 
Closes #2322.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated transaction execution to reference the actual previous state root during forkchoice updates, enhancing synchronization with the current blockchain state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->