### PR TITLE
fix: Modify Evolve node logging to remove noise

### DIFF
--- a/block/manager.go
+++ b/block/manager.go
@@ -656,7 +656,7 @@ func (m *Manager) publishBlockInternal(ctx context.Context) error {
 					m.logger.Info("no batch retrieved from sequencer, skipping block production")
 					return nil
 				}
-				m.logger.Debug("creating empty block, height: ", newHeight)
+				m.logger.Info("creating empty block, height: ", newHeight)
 			} else {
 				m.logger.Warn("failed to get transactions from batch", "error", err)
 				return nil
@@ -665,8 +665,7 @@ func (m *Manager) publishBlockInternal(ctx context.Context) error {
 			if batchData.Before(lastHeaderTime) {
 				return fmt.Errorf("timestamp is not monotonically increasing: %s < %s", batchData.Time, m.getLastBlockTime())
 			}
-			m.logger.Info("creating and publishing block", "height", newHeight)
-			m.logger.Debug("block info", "num_tx", len(batchData.Transactions))
+			m.logger.Info("creating and publishing block", "height", newHeight, "num_tx", len(batchData.Transactions))
 		}
 
 		header, data, err = m.createBlock(ctx, newHeight, lastSignature, lastHeaderHash, batchData)

--- a/block/submitter.go
+++ b/block/submitter.go
@@ -125,7 +125,7 @@ func submitToDA[T any](
 			// Record successful DA submission
 			m.recordDAMetrics("submission", DAModeSuccess)
 
-			m.logger.Info(fmt.Sprintf("successfully submitted %s to DA layer", itemType), "gasPrice", gasPrice, "count", res.SubmittedCount)
+			m.logger.Info(fmt.Sprintf("successfully submitted %s to DA layer with gasPrice %v and count %d", itemType, gasPrice, res.SubmittedCount))
 			if res.SubmittedCount == uint64(remLen) {
 				submittedAll = true
 			}

--- a/pkg/cmd/run_node.go
+++ b/pkg/cmd/run_node.go
@@ -67,10 +67,12 @@ func SetupLogger(config rollconf.LogConfig) logging.EventLogger {
 
 	logging.SetupLogging(logCfg)
 
-	// Suppress noisy external component logs by setting them to FATAL level
-	_ = logging.SetLogLevel("header/store", "FATAL")
-	_ = logging.SetLogLevel("header/sync", "FATAL")
-	_ = logging.SetLogLevel("header/p2p", "FATAL")
+	// Suppress noisy external component logs by default, unless debug logging is enabled
+	if logCfg.Level != logging.LevelDebug {
+		_ = logging.SetLogLevel("header/store", "FATAL")
+		_ = logging.SetLogLevel("header/sync", "FATAL")
+		_ = logging.SetLogLevel("header/p2p", "FATAL")
+	}
 
 	// Return a logger instance for the "main" subsystem
 	return logging.Logger("main")

--- a/pkg/cmd/run_node.go
+++ b/pkg/cmd/run_node.go
@@ -67,6 +67,11 @@ func SetupLogger(config rollconf.LogConfig) logging.EventLogger {
 
 	logging.SetupLogging(logCfg)
 
+	// Suppress noisy external component logs by setting them to FATAL level
+	_ = logging.SetLogLevel("header/store", "FATAL")
+	_ = logging.SetLogLevel("header/sync", "FATAL")
+	_ = logging.SetLogLevel("header/p2p", "FATAL")
+
 	// Return a logger instance for the "main" subsystem
 	return logging.Logger("main")
 }


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

After https://github.com/evstack/ev-node/pull/2416/ was merged, the logging in evolve node included logs from the headerSyncService's p2p module, store module, and sync module via the go-header library. This caused a lot of noise in evolve node logs and shouldn't be enabled by default.

Also, made the `creating empty block` log back to INFO level so a user can see that evolve node is producing blocks when during no user activity and see what block height the node is at.

Also, fixes formatting issues with DA submission log.

https://www.loom.com/share/42b4be68bee74608b62cfdf07324a829?sid=4f889192-639b-477e-b5c6-fe941d6c7f70

Previously logging looked like this:

<img width="2166" height="1066" alt="image" src="https://github.com/user-attachments/assets/1f0a0e16-e777-45c6-ab43-5ec0f65525fb" />


Logging now looks like this:

<img width="1092" height="301" alt="image" src="https://github.com/user-attachments/assets/683604df-3e32-4fad-93c0-2d9e58c9feaa" />


<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->
