### PR TITLE
fix: eliminate gas price/multiplier duplication

### DIFF
--- a/block/manager.go
+++ b/block/manager.go
@@ -151,8 +151,6 @@ type Manager struct {
 	// in the DA
 	daIncludedHeight atomic.Uint64
 	da               coreda.DA
-	gasPrice         float64
-	gasMultiplier    float64
 
 	sequencer     coresequencer.Sequencer
 	lastBatchData [][]byte
@@ -310,8 +308,6 @@ func NewManager(
 	headerBroadcaster broadcaster[*types.SignedHeader],
 	dataBroadcaster broadcaster[*types.Data],
 	seqMetrics *Metrics,
-	gasPrice float64,
-	gasMultiplier float64,
 	managerOpts ManagerOptions,
 ) (*Manager, error) {
 	s, err := getInitialState(ctx, genesis, signer, store, exec, logger, managerOpts)
@@ -402,8 +398,6 @@ func NewManager(
 		sequencer:                   sequencer,
 		exec:                        exec,
 		da:                          da,
-		gasPrice:                    gasPrice,
-		gasMultiplier:               gasMultiplier,
 		txNotifyCh:                  make(chan struct{}, 1), // Non-blocking channel
 		signaturePayloadProvider:    managerOpts.SignaturePayloadProvider,
 		validatorHasherProvider:     managerOpts.ValidatorHasherProvider,

--- a/node/full.go
+++ b/node/full.go
@@ -110,8 +110,6 @@ func newFullNode(
 		headerSyncService,
 		dataSyncService,
 		seqMetrics,
-		nodeConfig.DA.GasPrice,
-		nodeConfig.DA.GasMultiplier,
 		nodeOpts.ManagerOptions,
 	)
 	if err != nil {
@@ -197,8 +195,6 @@ func initBlockManager(
 	headerSyncService *evsync.HeaderSyncService,
 	dataSyncService *evsync.DataSyncService,
 	seqMetrics *block.Metrics,
-	gasPrice float64,
-	gasMultiplier float64,
 	managerOpts block.ManagerOptions,
 ) (*block.Manager, error) {
 	logger.Debug().Bytes("address", genesis.ProposerAddress).Msg("Proposer address")
@@ -218,8 +214,6 @@ func initBlockManager(
 		headerSyncService,
 		dataSyncService,
 		seqMetrics,
-		gasPrice,
-		gasMultiplier,
 		managerOpts,
 	)
 	if err != nil {


### PR DESCRIPTION
Fixes #2316

This PR eliminates the duplication of gas price and gas multiplier by using the DA interface as the single source of truth.

## Changes
- Remove `gasPrice` and `gasMultiplier` fields from Manager struct
- Update `submitToDA` function to call DA interface methods
- Remove gas parameters from `NewManager` constructor
- Update tests to mock DA interface methods
- Add proper error handling with fallback defaults

## Benefits
- Single source of truth for gas parameters
- Enables dynamic gas pricing by DA implementations
- Reduces configuration complexity
- Maintains backward compatibility

Generated with [Claude Code](https://claude.ai/code)