### PR TITLE
docs: clarify DA-only sync mode configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Ev-node is the basis of the Evolve Stack. For more in-depth information about Ev
 
 ## Using Evolve
 
+Evolve supports multiple sync modes:
+- **Hybrid sync**: Sync from both DA layer and P2P network (default when peers are configured)
+- **DA-only sync**: Sync exclusively from DA layer by leaving P2P peers empty (see [Configuration Guide](docs/learn/config.md#da-only-sync-mode))
+- **P2P-priority sync**: Prioritize P2P with DA as fallback
+
 ### Example Implementation: TestApp CLI
 
 The easiest way to understand how to use Evolve is by exploring our example implementation, TestApp.

--- a/docs/learn/config.md
+++ b/docs/learn/config.md
@@ -4,6 +4,7 @@ This document provides a comprehensive reference for all configuration options a
 
 ## Table of Contents
 
+- [DA-Only Sync Mode](#da-only-sync-mode)
 - [Introduction to Configurations](#introduction-to-configurations)
 - [Base Configuration](#base-configuration)
   - [Root Directory](#root-directory)
@@ -48,6 +49,41 @@ This document provides a comprehensive reference for all configuration options a
   - [Signer Type](#signer-type)
   - [Signer Path](#signer-path)
   - [Signer Passphrase](#signer-passphrase)
+
+## DA-Only Sync Mode
+
+Evolve supports running nodes that sync exclusively from the Data Availability (DA) layer without participating in P2P networking. This mode is useful for:
+
+- **Pure DA followers**: Nodes that only need the canonical chain data from DA
+- **Resource optimization**: Reducing network overhead by avoiding P2P gossip
+- **Simplified deployment**: No need to configure or maintain P2P peer connections
+- **Isolated environments**: Nodes that should not participate in P2P communication
+
+**To enable DA-only sync mode:**
+
+1. **Leave P2P peers empty** (default behavior):
+   ```yaml
+   p2p:
+     peers: ""  # Empty or omit this field entirely
+   ```
+   
+2. **Configure DA connection** (required):
+   ```yaml
+   da:
+     address: "your-da-service:port"
+     namespace: "your-namespace"
+     # ... other DA configuration
+   ```
+
+3. **Optional**: You can still configure P2P listen address for potential future connections, but without peers, no P2P networking will occur.
+
+When running in DA-only mode, the node will:
+- ✅ Sync blocks and headers from the DA layer
+- ✅ Validate transactions and maintain state
+- ✅ Serve RPC requests
+- ❌ Not participate in P2P gossip or peer discovery
+- ❌ Not share blocks with other nodes via P2P
+- ❌ Not receive transactions via P2P (only from direct RPC submission)
 
 ## Configs
 
@@ -461,17 +497,21 @@ p2p:
 **Description:**
 A comma-separated list of peer addresses (e.g., multiaddresses) that the node will attempt to connect to for bootstrapping its P2P connections. These are often referred to as seed nodes.
 
+**For DA-only sync mode:** Leave this field empty (default) to disable P2P networking entirely. When no peers are configured, the node will sync exclusively from the Data Availability layer without participating in P2P gossip, peer discovery, or block sharing. This is useful for nodes that only need to follow the canonical chain data from DA.
+
 **YAML:**
 
 ```yaml
 p2p:
   peers: "/ip4/some_peer_ip/tcp/7676/p2p/PEER_ID1,/ip4/another_peer_ip/tcp/7676/p2p/PEER_ID2"
+  # For DA-only sync, leave peers empty:
+  # peers: ""
 ```
 
 **Command-line Flag:**
 `--rollkit.p2p.peers <string>`
 *Example:* `--rollkit.p2p.peers /dns4/seed.example.com/tcp/26656/p2p/12D3KooW...`
-*Default:* `""` (empty)
+*Default:* `""` (empty - enables DA-only sync mode)
 *Constant:* `FlagP2PPeers`
 
 ### P2P Blocked Peers


### PR DESCRIPTION
Addresses #issue 1671 by documenting that DA-only sync is already supported by not configuring P2P peers.

## Changes
- Added dedicated DA-Only Sync Mode section in config.md
- Enhanced P2P Peers documentation to explain DA-only behavior
- Updated README to highlight sync mode options
- Provided clear configuration examples and use cases

closes #1671 

Generated with [Claude Code](https://claude.ai/code)