### PR TITLE
fix: persist last queried DA Height across full node restarts

### DIFF
--- a/block/retriever.go
+++ b/block/retriever.go
@@ -47,7 +47,13 @@ func (m *Manager) RetrieveLoop(ctx context.Context) {
 		case blobsFoundCh <- struct{}{}:
 		default:
 		}
-		m.daHeight.Store(daHeight + 1)
+		newDAHeight := daHeight + 1
+		m.daHeight.Store(newDAHeight)
+		
+		// Persist the updated DA height in the state to survive restarts
+		if err := m.persistDAHeight(ctx, newDAHeight); err != nil {
+			m.logger.Error().Err(err).Uint64("newDAHeight", newDAHeight).Msg("failed to persist DA height")
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes issue where full nodes restart DA querying from block 0 instead of continuing from the last processed height.

**Changes**:
- Modified manager initialization to only use DA StartHeight for fresh starts
- Enhanced RetrieveLoop to persist DA height updates after successful queries
- Added persistDAHeight() method for safe state updates

Fixes #2551

Generated with [Claude Code](https://claude.ai/code)