### PR TITLE
security: fix RUSTSEC-2025-0047 - upgrade slab from 0.4.10 to 0.4.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,9 +1008,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "8306e1e54e8def4f91e6c55c8d0dd8d3dc9ea8e99dc6a9fb91cff969b6dd8dc8"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ prost-types = "0.12"
 tonic = { version = "0.10", features = ["transport"] }
 tonic-build = "0.10"
 walkdir = "2.5.0"
+slab = "0.4.11"


### PR DESCRIPTION
This addresses the security vulnerability in slab v0.4.10 where get_disjoint_mut incorrectly checked indices against capacity instead of length, allowing out-of-bounds access to uninitialized memory.

- Added slab = "0.4.11" to workspace dependencies
- Updated Cargo.lock to use patched version

Fixes #2563

Generated with [Claude Code](https://claude.ai/code)