### PR TITLE
refactor: Use built-in clear to zero byte slice

### DIFF
--- a/pkg/signer/file/local.go
+++ b/pkg/signer/file/local.go
@@ -436,9 +436,7 @@ func fallbackDeriveKey(passphrase []byte, keyLen int) []byte {
 
 // zeroBytes overwrites a byte slice with zeros
 func zeroBytes(b []byte) {
-	for i := range b {
-		b[i] = 0
-	}
+	clear(b)
 }
 
 // getAddress returns the Ed25519 address of the signer.


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

Replace the manual for-loop with a call to the built-in clear function to set all elements of the slice to their zero value.  This change improves code readability and makes the intent more explicit.  

This is the idiomatic approach for this operation since Go 1.21.

