### PR TITLE
fix(block): validate block after applying instead of before during sync

### DIFF
--- a/block/sync.go
+++ b/block/sync.go
@@ -149,14 +149,15 @@ func (m *Manager) trySyncNextBlock(ctx context.Context, daHeight uint64) error {
 		// set the custom verifier to ensure proper signature validation
 		h.SetCustomVerifier(m.signaturePayloadProvider)
 
-		// validate the received block before applying
-		if err := m.Validate(ctx, h, d); err != nil {
-			return fmt.Errorf("failed to validate block: %w", err)
-		}
-
 		newState, err := m.applyBlock(ctx, h.Header, d)
 		if err != nil {
 			return fmt.Errorf("failed to apply block: %w", err)
+		}
+
+		// validate the received block after applying
+		// a custom verification function can depend on the state of the blockchain
+		if err := m.Validate(ctx, h, d); err != nil {
+			return fmt.Errorf("failed to validate block: %w", err)
 		}
 
 		if err = m.updateState(ctx, newState); err != nil {


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

We validate after during execution, but before during syncing, but the signature verifier provided by ev-abci needs some data that is saved after applying.


<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->
