### PR TITLE
test: fix docker e2e test and bump celestia-app version

### DIFF
--- a/test/docker-e2e/base_test.go
+++ b/test/docker-e2e/base_test.go
@@ -45,18 +45,18 @@ func (s *DockerTestSuite) TestBasicDockerE2E() {
 	})
 
 	s.T().Run("start evolve chain node", func(t *testing.T) {
-		s.StartRollkitNode(ctx, bridgeNode, s.rollkitChain.GetNodes()[0])
+		s.StartEvNode(ctx, bridgeNode, s.evNodeChain.GetNodes()[0])
 	})
 
 	s.T().Run("submit a transaction to the evolve chain", func(t *testing.T) {
-		rollkitNode := s.rollkitChain.GetNodes()[0]
+		rollkitNode := s.evNodeChain.GetNodes()[0]
 
 		// Debug: Check if the node is running and all ports
 		t.Logf("Rollkit node RPC port: %s", rollkitNode.GetHostRPCPort())
 		t.Logf("Rollkit node GRPC port: %s", rollkitNode.GetHostGRPCPort())
 		t.Logf("Rollkit node P2P port: %s", rollkitNode.GetHostP2PPort())
 
-// The http port resolvable by the test runner.
+		// The http port resolvable by the test runner.
 		httpPortStr := rollkitNode.GetHostHTTPPort()
 		t.Logf("Rollkit node HTTP port: %s", httpPortStr)
 

--- a/test/docker-e2e/go.mod
+++ b/test/docker-e2e/go.mod
@@ -7,7 +7,6 @@ require github.com/celestiaorg/tastora v0.2.3
 require (
 	cosmossdk.io/x/upgrade v0.1.4 // indirect
 	github.com/chzyer/readline v1.5.1 // indirect
-	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/cosmos/ibc-go/modules/capability v1.0.1 // indirect
 	github.com/cosmos/ibc-go/v8 v8.7.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
@@ -223,4 +222,5 @@ replace (
 	github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v1.53.0-tm-v0.38.17
 	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.29.1-sdk-v0.50.12
 	github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+	github.com/moby/moby => github.com/moby/moby v27.5.1+incompatible
 )

--- a/test/docker-e2e/go.sum
+++ b/test/docker-e2e/go.sum
@@ -219,8 +219,6 @@ github.com/containerd/continuity v0.3.0 h1:nisirsYROK15TAMVukJOUyGJjz4BNQJBVsNvA
 github.com/containerd/continuity v0.3.0/go.mod h1:wJEAIwKOm/pBZuBd0JmeTvnLquTB1Ag8espWhkykbPM=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
-github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=
-github.com/containerd/errdefs/pkg v0.3.0/go.mod h1:NJw6s9HwNuRhnjJhM7pylWwMyAkmCQvQ4GpJHEqRLVk=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
@@ -633,8 +631,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
-github.com/moby/moby v28.3.3+incompatible h1:nzkZIIn9bQP9S553kNmJ+U8PBhdS2ciFWphV2vX/Zp4=
-github.com/moby/moby v28.3.3+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
+github.com/moby/moby v27.5.1+incompatible h1:/pN59F/t3U7Q4FPzV88nzqf7Fp0qqCSL2KzhZaiKcKw=
+github.com/moby/moby v27.5.1+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
 github.com/moby/sys/atomicwriter v0.1.0 h1:kw5D/EqkBwsBFi0ss9v1VG3wIkVhzGvLklJ+w3A14Sw=
 github.com/moby/sys/atomicwriter v0.1.0/go.mod h1:Ul8oqv2ZMNHOceF643P6FKPXeCmYtlQMvpizfsSoaWs=
 github.com/moby/sys/sequential v0.6.0 h1:qrx7XFUd/5DxtqcoH1h438hF5TmOvzC/lspjy7zgvCU=


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

The test was failing due to a different version of the moby/moby client being pulled in from somewhere, I pinned the version to be the one that tastora uses.

I also bumped celestia-app to be v5 and did some renaming of rollkit => ev-node

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->
