### PR TITLE
feat: add namespace cfg validation + random default

### DIFF
--- a/apps/evm/single/go.mod
+++ b/apps/evm/single/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/bits-and-blooms/bitset v1.20.0 // indirect
 	github.com/buger/goterm v1.0.4 // indirect
 	github.com/celestiaorg/go-libp2p-messenger v0.2.2 // indirect
+	github.com/celestiaorg/go-square/v2 v2.3.3 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/apps/evm/single/go.sum
+++ b/apps/evm/single/go.sum
@@ -106,6 +106,8 @@ github.com/celestiaorg/go-datastore v0.0.0-20250801131506-48a63ae531e4 h1:udw77B
 github.com/celestiaorg/go-datastore v0.0.0-20250801131506-48a63ae531e4/go.mod h1:W+pI1NsUsz3tcsAACMtfC+IZdnQTnC/7VfPoJBQuts0=
 github.com/celestiaorg/go-libp2p-messenger v0.2.2 h1:osoUfqjss7vWTIZrrDSy953RjQz+ps/vBFE7bychLEc=
 github.com/celestiaorg/go-libp2p-messenger v0.2.2/go.mod h1:oTCRV5TfdO7V/k6nkx7QjQzGrWuJbupv+0o1cgnY2i4=
+github.com/celestiaorg/go-square/v2 v2.3.3 h1:vhu6Lt39km19Q/Jk4nS3r2cuWJq6jFg+/1+iG8YGftY=
+github.com/celestiaorg/go-square/v2 v2.3.3/go.mod h1:vY5RRv+qRmEVjPF6dAdr0dyLwKmTTDHHffENPQw8pUA=
 github.com/celestiaorg/utils v0.1.0 h1:WsP3O8jF7jKRgLNFmlDCwdThwOFMFxg0MnqhkLFVxPo=
 github.com/celestiaorg/utils v0.1.0/go.mod h1:vQTh7MHnvpIeCQZ2/Ph+w7K1R2UerDheZbgJEJD2hSU=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=

--- a/apps/grpc/single/go.mod
+++ b/apps/grpc/single/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/celestiaorg/go-header v0.7.2 // indirect
 	github.com/celestiaorg/go-libp2p-messenger v0.2.2 // indirect
+	github.com/celestiaorg/go-square/v2 v2.3.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect

--- a/apps/grpc/single/go.sum
+++ b/apps/grpc/single/go.sum
@@ -28,6 +28,8 @@ github.com/celestiaorg/go-header v0.7.2 h1:Jw01iBKnodfsILzynDCU3C11xurpoBt5SI9lg
 github.com/celestiaorg/go-header v0.7.2/go.mod h1:eX9iTSPthVEAlEDLux40ZT/olXPGhpxHd+mEzJeDhd0=
 github.com/celestiaorg/go-libp2p-messenger v0.2.2 h1:osoUfqjss7vWTIZrrDSy953RjQz+ps/vBFE7bychLEc=
 github.com/celestiaorg/go-libp2p-messenger v0.2.2/go.mod h1:oTCRV5TfdO7V/k6nkx7QjQzGrWuJbupv+0o1cgnY2i4=
+github.com/celestiaorg/go-square/v2 v2.3.3 h1:vhu6Lt39km19Q/Jk4nS3r2cuWJq6jFg+/1+iG8YGftY=
+github.com/celestiaorg/go-square/v2 v2.3.3/go.mod h1:vY5RRv+qRmEVjPF6dAdr0dyLwKmTTDHHffENPQw8pUA=
 github.com/celestiaorg/utils v0.1.0 h1:WsP3O8jF7jKRgLNFmlDCwdThwOFMFxg0MnqhkLFVxPo=
 github.com/celestiaorg/utils v0.1.0/go.mod h1:vQTh7MHnvpIeCQZ2/Ph+w7K1R2UerDheZbgJEJD2hSU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/apps/testapp/go.mod
+++ b/apps/testapp/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/celestiaorg/go-libp2p-messenger v0.2.2 // indirect
+	github.com/celestiaorg/go-square/v2 v2.3.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect

--- a/apps/testapp/go.sum
+++ b/apps/testapp/go.sum
@@ -26,6 +26,8 @@ github.com/celestiaorg/go-datastore v0.0.0-20250801131506-48a63ae531e4 h1:udw77B
 github.com/celestiaorg/go-datastore v0.0.0-20250801131506-48a63ae531e4/go.mod h1:W+pI1NsUsz3tcsAACMtfC+IZdnQTnC/7VfPoJBQuts0=
 github.com/celestiaorg/go-libp2p-messenger v0.2.2 h1:osoUfqjss7vWTIZrrDSy953RjQz+ps/vBFE7bychLEc=
 github.com/celestiaorg/go-libp2p-messenger v0.2.2/go.mod h1:oTCRV5TfdO7V/k6nkx7QjQzGrWuJbupv+0o1cgnY2i4=
+github.com/celestiaorg/go-square/v2 v2.3.3 h1:vhu6Lt39km19Q/Jk4nS3r2cuWJq6jFg+/1+iG8YGftY=
+github.com/celestiaorg/go-square/v2 v2.3.3/go.mod h1:vY5RRv+qRmEVjPF6dAdr0dyLwKmTTDHHffENPQw8pUA=
 github.com/celestiaorg/utils v0.1.0 h1:WsP3O8jF7jKRgLNFmlDCwdThwOFMFxg0MnqhkLFVxPo=
 github.com/celestiaorg/utils v0.1.0/go.mod h1:vQTh7MHnvpIeCQZ2/Ph+w7K1R2UerDheZbgJEJD2hSU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/block/components_test.go
+++ b/block/components_test.go
@@ -83,7 +83,7 @@ func TestNewSyncComponents_Creation(t *testing.T) {
 	ds := sync.MutexWrap(datastore.NewMapDatastore())
 	memStore := store.New(ds)
 
-	cfg := config.DefaultConfig
+	cfg := config.DefaultConfig()
 	gen := genesis.Genesis{
 		ChainID:         "test-chain",
 		InitialHeight:   1,
@@ -122,7 +122,7 @@ func TestNewAggregatorComponents_Creation(t *testing.T) {
 	ds := sync.MutexWrap(datastore.NewMapDatastore())
 	memStore := store.New(ds)
 
-	cfg := config.DefaultConfig
+	cfg := config.DefaultConfig()
 
 	// Create a test signer first
 	priv, _, err := crypto.GenerateEd25519Key(crand.Reader)
@@ -176,7 +176,7 @@ func TestExecutor_RealExecutionClientFailure_StopsNode(t *testing.T) {
 	ds := sync.MutexWrap(datastore.NewMapDatastore())
 	memStore := store.New(ds)
 
-	cfg := config.DefaultConfig
+	cfg := config.DefaultConfig()
 	cfg.Node.BlockTime.Duration = 50 * time.Millisecond // Fast for testing
 
 	// Create test signer

--- a/block/internal/cache/bench_test.go
+++ b/block/internal/cache/bench_test.go
@@ -46,7 +46,7 @@ func benchSetupStore(b *testing.B, n int, txsPer int, chainID string) store.Stor
 }
 
 func benchNewManager(b *testing.B, st store.Store) Manager {
-	cfg := config.DefaultConfig
+	cfg := config.DefaultConfig()
 	cfg.RootDir = b.TempDir()
 	m, err := NewManager(cfg, st, zerolog.Nop())
 	if err != nil {

--- a/block/internal/cache/manager_test.go
+++ b/block/internal/cache/manager_test.go
@@ -18,7 +18,7 @@ import (
 
 // helper to make a temp config rooted at t.TempDir()
 func tempConfig(t *testing.T) config.Config {
-	cfg := config.DefaultConfig
+	cfg := config.DefaultConfig()
 	cfg.RootDir = t.TempDir()
 	return cfg
 }

--- a/block/internal/executing/executor_lazy_test.go
+++ b/block/internal/executing/executor_lazy_test.go
@@ -26,14 +26,14 @@ func TestLazyMode_ProduceBlockLogic(t *testing.T) {
 	ds := sync.MutexWrap(datastore.NewMapDatastore())
 	memStore := store.New(ds)
 
-	cacheManager, err := cache.NewManager(config.DefaultConfig, memStore, zerolog.Nop())
+	cacheManager, err := cache.NewManager(config.DefaultConfig(), memStore, zerolog.Nop())
 	require.NoError(t, err)
 
 	metrics := common.NopMetrics()
 
 	addr, _, signerWrapper := buildTestSigner(t)
 
-	cfg := config.DefaultConfig
+	cfg := config.DefaultConfig()
 	cfg.Node.BlockTime = config.DurationWrapper{Duration: 10 * time.Millisecond}
 	cfg.Node.LazyMode = true
 	cfg.Node.MaxPendingHeadersAndData = 1000
@@ -134,14 +134,14 @@ func TestRegularMode_ProduceBlockLogic(t *testing.T) {
 	ds := sync.MutexWrap(datastore.NewMapDatastore())
 	memStore := store.New(ds)
 
-	cacheManager, err := cache.NewManager(config.DefaultConfig, memStore, zerolog.Nop())
+	cacheManager, err := cache.NewManager(config.DefaultConfig(), memStore, zerolog.Nop())
 	require.NoError(t, err)
 
 	metrics := common.NopMetrics()
 
 	addr, _, signerWrapper := buildTestSigner(t)
 
-	cfg := config.DefaultConfig
+	cfg := config.DefaultConfig()
 	cfg.Node.BlockTime = config.DurationWrapper{Duration: 10 * time.Millisecond}
 	cfg.Node.LazyMode = false // Regular mode
 	cfg.Node.MaxPendingHeadersAndData = 1000

--- a/block/internal/executing/executor_logic_test.go
+++ b/block/internal/executing/executor_logic_test.go
@@ -44,7 +44,7 @@ func TestProduceBlock_EmptyBatch_SetsEmptyDataHash(t *testing.T) {
 	ds := sync.MutexWrap(datastore.NewMapDatastore())
 	memStore := store.New(ds)
 
-	cacheManager, err := cache.NewManager(config.DefaultConfig, memStore, zerolog.Nop())
+	cacheManager, err := cache.NewManager(config.DefaultConfig(), memStore, zerolog.Nop())
 	require.NoError(t, err)
 
 	metrics := common.NopMetrics()
@@ -52,7 +52,7 @@ func TestProduceBlock_EmptyBatch_SetsEmptyDataHash(t *testing.T) {
 	// signer and genesis with correct proposer
 	addr, _, signerWrapper := buildTestSigner(t)
 
-	cfg := config.DefaultConfig
+	cfg := config.DefaultConfig()
 	cfg.Node.BlockTime = config.DurationWrapper{Duration: 10 * time.Millisecond}
 	cfg.Node.MaxPendingHeadersAndData = 1000
 
@@ -134,14 +134,14 @@ func TestPendingLimit_SkipsProduction(t *testing.T) {
 	ds := sync.MutexWrap(datastore.NewMapDatastore())
 	memStore := store.New(ds)
 
-	cacheManager, err := cache.NewManager(config.DefaultConfig, memStore, zerolog.Nop())
+	cacheManager, err := cache.NewManager(config.DefaultConfig(), memStore, zerolog.Nop())
 	require.NoError(t, err)
 
 	metrics := common.NopMetrics()
 
 	addr, _, signerWrapper := buildTestSigner(t)
 
-	cfg := config.DefaultConfig
+	cfg := config.DefaultConfig()
 	cfg.Node.BlockTime = config.DurationWrapper{Duration: 10 * time.Millisecond}
 	cfg.Node.MaxPendingHeadersAndData = 1 // low limit to trigger skip quickly
 

--- a/block/internal/executing/executor_restart_test.go
+++ b/block/internal/executing/executor_restart_test.go
@@ -27,13 +27,13 @@ func TestExecutor_RestartUsesPendingHeader(t *testing.T) {
 	ds := sync.MutexWrap(datastore.NewMapDatastore())
 	memStore := store.New(ds)
 
-	cacheManager, err := cache.NewManager(config.DefaultConfig, memStore, zerolog.Nop())
+	cacheManager, err := cache.NewManager(config.DefaultConfig(), memStore, zerolog.Nop())
 	require.NoError(t, err)
 
 	metrics := common.NopMetrics()
 	addr, _, signerWrapper := buildTestSigner(t)
 
-	cfg := config.DefaultConfig
+	cfg := config.DefaultConfig()
 	cfg.Node.BlockTime = config.DurationWrapper{Duration: 10 * time.Millisecond}
 	cfg.Node.MaxPendingHeadersAndData = 1000
 
@@ -238,13 +238,13 @@ func TestExecutor_RestartNoPendingHeader(t *testing.T) {
 	ds := sync.MutexWrap(datastore.NewMapDatastore())
 	memStore := store.New(ds)
 
-	cacheManager, err := cache.NewManager(config.DefaultConfig, memStore, zerolog.Nop())
+	cacheManager, err := cache.NewManager(config.DefaultConfig(), memStore, zerolog.Nop())
 	require.NoError(t, err)
 
 	metrics := common.NopMetrics()
 	addr, _, signerWrapper := buildTestSigner(t)
 
-	cfg := config.DefaultConfig
+	cfg := config.DefaultConfig()
 	cfg.Node.BlockTime = config.DurationWrapper{Duration: 10 * time.Millisecond}
 	cfg.Node.MaxPendingHeadersAndData = 1000
 

--- a/block/internal/executing/executor_test.go
+++ b/block/internal/executing/executor_test.go
@@ -37,7 +37,7 @@ func TestExecutor_BroadcasterIntegration(t *testing.T) {
 	memStore := store.New(ds)
 
 	// Create cache
-	cacheManager, err := cache.NewManager(config.DefaultConfig, memStore, zerolog.Nop())
+	cacheManager, err := cache.NewManager(config.DefaultConfig(), memStore, zerolog.Nop())
 	require.NoError(t, err)
 
 	metrics := common.NopMetrics()
@@ -63,7 +63,7 @@ func TestExecutor_BroadcasterIntegration(t *testing.T) {
 		testSigner, // test signer (required for executor)
 		cacheManager,
 		metrics,
-		config.DefaultConfig,
+		config.DefaultConfig(),
 		gen,
 		headerBroadcaster,
 		dataBroadcaster,
@@ -91,7 +91,7 @@ func TestExecutor_NilBroadcasters(t *testing.T) {
 	memStore := store.New(ds)
 
 	// Create cache
-	cacheManager, err := cache.NewManager(config.DefaultConfig, memStore, zerolog.Nop())
+	cacheManager, err := cache.NewManager(config.DefaultConfig(), memStore, zerolog.Nop())
 	require.NoError(t, err)
 
 	metrics := common.NopMetrics()
@@ -113,7 +113,7 @@ func TestExecutor_NilBroadcasters(t *testing.T) {
 		testSigner, // test signer (required for executor)
 		cacheManager,
 		metrics,
-		config.DefaultConfig,
+		config.DefaultConfig(),
 		gen,
 		nil, // nil header broadcaster
 		nil, // nil data broadcaster

--- a/block/internal/reaping/reaper_test.go
+++ b/block/internal/reaping/reaper_test.go
@@ -43,7 +43,7 @@ func newTestExecutor(t *testing.T) *executing.Executor {
 		s,   // signer (required)
 		nil, // cache (unused)
 		nil, // metrics (unused)
-		config.DefaultConfig,
+		config.DefaultConfig(),
 		genesis.Genesis{ // minimal genesis
 			ChainID:         "test-chain",
 			InitialHeight:   1,

--- a/block/internal/submitting/da_submitter_integration_test.go
+++ b/block/internal/submitting/da_submitter_integration_test.go
@@ -26,7 +26,7 @@ import (
 func TestDASubmitter_SubmitHeadersAndData_MarksInclusionAndUpdatesLastSubmitted(t *testing.T) {
 	ds := sync.MutexWrap(datastore.NewMapDatastore())
 	st := store.New(ds)
-	cm, err := cache.NewManager(config.DefaultConfig, st, zerolog.Nop())
+	cm, err := cache.NewManager(config.DefaultConfig(), st, zerolog.Nop())
 	require.NoError(t, err)
 
 	// signer and proposer
@@ -39,7 +39,7 @@ func TestDASubmitter_SubmitHeadersAndData_MarksInclusionAndUpdatesLastSubmitted(
 	pub, err := n.GetPublic()
 	require.NoError(t, err)
 
-	cfg := config.DefaultConfig
+	cfg := config.DefaultConfig()
 	cfg.DA.Namespace = "ns-header"
 	cfg.DA.DataNamespace = "ns-data"
 

--- a/block/internal/submitting/da_submitter_test.go
+++ b/block/internal/submitting/da_submitter_test.go
@@ -30,14 +30,14 @@ func setupDASubmitterTest(t *testing.T) (*DASubmitter, store.Store, cache.Manage
 	// Create store and cache
 	ds := sync.MutexWrap(datastore.NewMapDatastore())
 	st := store.New(ds)
-	cm, err := cache.NewManager(config.DefaultConfig, st, zerolog.Nop())
+	cm, err := cache.NewManager(config.DefaultConfig(), st, zerolog.Nop())
 	require.NoError(t, err)
 
 	// Create dummy DA
 	dummyDA := coreda.NewDummyDA(10_000_000, 0, 0, 10*time.Millisecond)
 
 	// Create config
-	cfg := config.DefaultConfig
+	cfg := config.DefaultConfig()
 	cfg.DA.Namespace = "test-headers"
 	cfg.DA.DataNamespace = "test-data"
 

--- a/block/internal/submitting/submitter_test.go
+++ b/block/internal/submitting/submitter_test.go
@@ -78,7 +78,7 @@ func TestSubmitter_setSequencerHeightToDAHeight(t *testing.T) {
 	// Use a mock store to validate metadata writes
 	mockStore := testmocks.NewMockStore(t)
 
-	cfg := config.DefaultConfig
+	cfg := config.DefaultConfig()
 	metrics := common.NopMetrics()
 	daSub := NewDASubmitter(nil, cfg, genesis.Genesis{}, common.DefaultBlockOptions(), zerolog.Nop())
 	s := NewSubmitter(mockStore, nil, cm, metrics, cfg, genesis.Genesis{}, daSub, nil, zerolog.Nop(), nil)
@@ -146,7 +146,7 @@ func TestSubmitter_processDAInclusionLoop_advances(t *testing.T) {
 	cm, st := newTestCacheAndStore(t)
 
 	// small block time to tick quickly
-	cfg := config.DefaultConfig
+	cfg := config.DefaultConfig()
 	cfg.DA.BlockTime.Duration = 5 * time.Millisecond
 	metrics := common.PrometheusMetrics("test")
 
@@ -215,7 +215,7 @@ func newHeaderAndData(chainID string, height uint64, nonEmpty bool) (*types.Sign
 
 func newTestCacheAndStore(t *testing.T) (cache.Manager, store.Store) {
 	st := store.New(dssync.MutexWrap(datastore.NewMapDatastore()))
-	cm, err := cache.NewManager(config.DefaultConfig, st, zerolog.Nop())
+	cm, err := cache.NewManager(config.DefaultConfig(), st, zerolog.Nop())
 	require.NoError(t, err)
 	return cm, st
 }
@@ -228,7 +228,7 @@ func TestSubmitter_daSubmissionLoop(t *testing.T) {
 	cm, st := newTestCacheAndStore(t)
 
 	// Set a small block time so the ticker fires quickly
-	cfg := config.DefaultConfig
+	cfg := config.DefaultConfig()
 	cfg.DA.BlockTime.Duration = 5 * time.Millisecond
 	metrics := common.NopMetrics()
 

--- a/block/internal/syncing/da_retriever_test.go
+++ b/block/internal/syncing/da_retriever_test.go
@@ -70,7 +70,7 @@ func makeSignedDataBytes(t *testing.T, chainID string, height uint64, proposer [
 func TestDARetriever_RetrieveFromDA_NotFound(t *testing.T) {
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
 	st := store.New(ds)
-	cm, err := cache.NewManager(config.DefaultConfig, st, zerolog.Nop())
+	cm, err := cache.NewManager(config.DefaultConfig(), st, zerolog.Nop())
 	require.NoError(t, err)
 
 	mockDA := testmocks.NewMockDA(t)
@@ -79,7 +79,7 @@ func TestDARetriever_RetrieveFromDA_NotFound(t *testing.T) {
 	mockDA.EXPECT().GetIDs(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, fmt.Errorf("%s: whatever", coreda.ErrBlobNotFound.Error())).Maybe()
 
-	r := NewDARetriever(mockDA, cm, config.DefaultConfig, genesis.Genesis{}, common.DefaultBlockOptions(), zerolog.Nop())
+	r := NewDARetriever(mockDA, cm, config.DefaultConfig(), genesis.Genesis{}, common.DefaultBlockOptions(), zerolog.Nop())
 	events, err := r.RetrieveFromDA(context.Background(), 42)
 	require.Error(t, err, coreda.ErrBlobNotFound)
 	assert.Len(t, events, 0)
@@ -88,7 +88,7 @@ func TestDARetriever_RetrieveFromDA_NotFound(t *testing.T) {
 func TestDARetriever_RetrieveFromDA_HeightFromFuture(t *testing.T) {
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
 	st := store.New(ds)
-	cm, err := cache.NewManager(config.DefaultConfig, st, zerolog.Nop())
+	cm, err := cache.NewManager(config.DefaultConfig(), st, zerolog.Nop())
 	require.NoError(t, err)
 
 	mockDA := testmocks.NewMockDA(t)
@@ -96,7 +96,7 @@ func TestDARetriever_RetrieveFromDA_HeightFromFuture(t *testing.T) {
 	mockDA.EXPECT().GetIDs(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, fmt.Errorf("%s: later", coreda.ErrHeightFromFuture.Error())).Maybe()
 
-	r := NewDARetriever(mockDA, cm, config.DefaultConfig, genesis.Genesis{}, common.DefaultBlockOptions(), zerolog.Nop())
+	r := NewDARetriever(mockDA, cm, config.DefaultConfig(), genesis.Genesis{}, common.DefaultBlockOptions(), zerolog.Nop())
 	events, derr := r.RetrieveFromDA(context.Background(), 1000)
 	assert.Error(t, derr)
 	assert.True(t, errors.Is(derr, coreda.ErrHeightFromFuture))
@@ -106,13 +106,13 @@ func TestDARetriever_RetrieveFromDA_HeightFromFuture(t *testing.T) {
 func TestDARetriever_ProcessBlobs_HeaderAndData_Success(t *testing.T) {
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
 	st := store.New(ds)
-	cm, err := cache.NewManager(config.DefaultConfig, st, zerolog.Nop())
+	cm, err := cache.NewManager(config.DefaultConfig(), st, zerolog.Nop())
 	require.NoError(t, err)
 
 	addr, pub, signer := buildSyncTestSigner(t)
 	gen := genesis.Genesis{ChainID: "tchain", InitialHeight: 1, StartTime: time.Now().Add(-time.Second), ProposerAddress: addr}
 
-	r := NewDARetriever(nil, cm, config.DefaultConfig, gen, common.DefaultBlockOptions(), zerolog.Nop())
+	r := NewDARetriever(nil, cm, config.DefaultConfig(), gen, common.DefaultBlockOptions(), zerolog.Nop())
 
 	// Build one header and one data blob at same height
 	_, lastState := types.State{}, types.State{}
@@ -132,12 +132,12 @@ func TestDARetriever_ProcessBlobs_HeaderAndData_Success(t *testing.T) {
 func TestDARetriever_ProcessBlobs_HeaderOnly_EmptyDataExpected(t *testing.T) {
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
 	st := store.New(ds)
-	cm, err := cache.NewManager(config.DefaultConfig, st, zerolog.Nop())
+	cm, err := cache.NewManager(config.DefaultConfig(), st, zerolog.Nop())
 	require.NoError(t, err)
 
 	addr, pub, signer := buildSyncTestSigner(t)
 	gen := genesis.Genesis{ChainID: "tchain", InitialHeight: 1, StartTime: time.Now().Add(-time.Second), ProposerAddress: addr}
-	r := NewDARetriever(nil, cm, config.DefaultConfig, gen, common.DefaultBlockOptions(), zerolog.Nop())
+	r := NewDARetriever(nil, cm, config.DefaultConfig(), gen, common.DefaultBlockOptions(), zerolog.Nop())
 
 	// Header with no data hash present should trigger empty data creation (per current logic)
 	hb, _ := makeSignedHeaderBytes(t, gen.ChainID, 3, addr, pub, signer, nil)
@@ -152,12 +152,12 @@ func TestDARetriever_ProcessBlobs_HeaderOnly_EmptyDataExpected(t *testing.T) {
 func TestDARetriever_TryDecodeHeaderAndData_Basic(t *testing.T) {
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
 	st := store.New(ds)
-	cm, err := cache.NewManager(config.DefaultConfig, st, zerolog.Nop())
+	cm, err := cache.NewManager(config.DefaultConfig(), st, zerolog.Nop())
 	require.NoError(t, err)
 
 	addr, pub, signer := buildSyncTestSigner(t)
 	gen := genesis.Genesis{ChainID: "tchain", InitialHeight: 1, StartTime: time.Now().Add(-time.Second), ProposerAddress: addr}
-	r := NewDARetriever(nil, cm, config.DefaultConfig, gen, common.DefaultBlockOptions(), zerolog.Nop())
+	r := NewDARetriever(nil, cm, config.DefaultConfig(), gen, common.DefaultBlockOptions(), zerolog.Nop())
 
 	hb, sh := makeSignedHeaderBytes(t, gen.ChainID, 5, addr, pub, signer, nil)
 	gotH := r.tryDecodeHeader(hb, 123)
@@ -187,13 +187,13 @@ func TestDARetriever_isEmptyDataExpected(t *testing.T) {
 func TestDARetriever_tryDecodeData_InvalidSignatureOrProposer(t *testing.T) {
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
 	st := store.New(ds)
-	cm, err := cache.NewManager(config.DefaultConfig, st, zerolog.Nop())
+	cm, err := cache.NewManager(config.DefaultConfig(), st, zerolog.Nop())
 	require.NoError(t, err)
 
 	goodAddr, pub, signer := buildSyncTestSigner(t)
 	badAddr := []byte("not-the-proposer")
 	gen := genesis.Genesis{ChainID: "tchain", InitialHeight: 1, StartTime: time.Now().Add(-time.Second), ProposerAddress: badAddr}
-	r := NewDARetriever(nil, cm, config.DefaultConfig, gen, common.DefaultBlockOptions(), zerolog.Nop())
+	r := NewDARetriever(nil, cm, config.DefaultConfig(), gen, common.DefaultBlockOptions(), zerolog.Nop())
 
 	// Signed data is made by goodAddr; retriever expects badAddr -> should be rejected
 	db, _ := makeSignedDataBytes(t, gen.ChainID, 7, goodAddr, pub, signer, 1)
@@ -217,7 +217,7 @@ func TestDARetriever_validateBlobResponse(t *testing.T) {
 func TestDARetriever_RetrieveFromDA_TwoNamespaces_Success(t *testing.T) {
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
 	st := store.New(ds)
-	cm, err := cache.NewManager(config.DefaultConfig, st, zerolog.Nop())
+	cm, err := cache.NewManager(config.DefaultConfig(), st, zerolog.Nop())
 	require.NoError(t, err)
 
 	addr, pub, signer := buildSyncTestSigner(t)
@@ -239,7 +239,7 @@ func TestDARetriever_RetrieveFromDA_TwoNamespaces_Success(t *testing.T) {
 	mockDA.EXPECT().Get(mock.Anything, mock.Anything, mock.MatchedBy(func(ns []byte) bool { return string(ns) == "nsData" })).
 		Return([][]byte{dataBin}, nil).Once()
 
-	cfg := config.DefaultConfig
+	cfg := config.DefaultConfig()
 	cfg.DA.Namespace = "nsHdr"
 	cfg.DA.DataNamespace = "nsData"
 

--- a/block/internal/syncing/syncer_logic_test.go
+++ b/block/internal/syncing/syncer_logic_test.go
@@ -71,12 +71,12 @@ func makeData(chainID string, height uint64, txs int) *types.Data {
 func TestProcessHeightEvent_SyncsAndUpdatesState(t *testing.T) {
 	ds := sync.MutexWrap(datastore.NewMapDatastore())
 	st := store.New(ds)
-	cm, err := cache.NewManager(config.DefaultConfig, st, zerolog.Nop())
+	cm, err := cache.NewManager(config.DefaultConfig(), st, zerolog.Nop())
 	require.NoError(t, err)
 
 	addr, pub, signer := buildSyncTestSigner(t)
 
-	cfg := config.DefaultConfig
+	cfg := config.DefaultConfig()
 	gen := genesis.Genesis{ChainID: "tchain", InitialHeight: 1, StartTime: time.Now().Add(-time.Second), ProposerAddress: addr}
 
 	mockExec := testmocks.NewMockExecutor(t)
@@ -123,11 +123,11 @@ func TestProcessHeightEvent_SyncsAndUpdatesState(t *testing.T) {
 func TestSequentialBlockSync(t *testing.T) {
 	ds := sync.MutexWrap(datastore.NewMapDatastore())
 	st := store.New(ds)
-	cm, err := cache.NewManager(config.DefaultConfig, st, zerolog.Nop())
+	cm, err := cache.NewManager(config.DefaultConfig(), st, zerolog.Nop())
 	require.NoError(t, err)
 
 	addr, pub, signer := buildSyncTestSigner(t)
-	cfg := config.DefaultConfig
+	cfg := config.DefaultConfig()
 	gen := genesis.Genesis{ChainID: "tchain", InitialHeight: 1, StartTime: time.Now().Add(-time.Second), ProposerAddress: addr}
 
 	mockExec := testmocks.NewMockExecutor(t)

--- a/block/internal/syncing/syncer_test.go
+++ b/block/internal/syncing/syncer_test.go
@@ -110,7 +110,7 @@ func TestSyncer_sendNonBlockingSignal(t *testing.T) {
 func TestSyncer_processPendingEvents(t *testing.T) {
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
 	st := store.New(ds)
-	cm, err := cache.NewManager(config.DefaultConfig, st, zerolog.Nop())
+	cm, err := cache.NewManager(config.DefaultConfig(), st, zerolog.Nop())
 	require.NoError(t, err)
 
 	// current height 1

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	connectrpc.com/connect v1.18.1
 	connectrpc.com/grpcreflect v1.3.0
 	github.com/celestiaorg/go-header v0.7.2
+	github.com/celestiaorg/go-square/v2 v2.3.3
 	github.com/celestiaorg/utils v0.1.0
 	github.com/evstack/ev-node/core v1.0.0-beta.2
 	github.com/go-kit/kit v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/celestiaorg/go-header v0.7.2 h1:Jw01iBKnodfsILzynDCU3C11xurpoBt5SI9lg
 github.com/celestiaorg/go-header v0.7.2/go.mod h1:eX9iTSPthVEAlEDLux40ZT/olXPGhpxHd+mEzJeDhd0=
 github.com/celestiaorg/go-libp2p-messenger v0.2.2 h1:osoUfqjss7vWTIZrrDSy953RjQz+ps/vBFE7bychLEc=
 github.com/celestiaorg/go-libp2p-messenger v0.2.2/go.mod h1:oTCRV5TfdO7V/k6nkx7QjQzGrWuJbupv+0o1cgnY2i4=
+github.com/celestiaorg/go-square/v2 v2.3.3 h1:vhu6Lt39km19Q/Jk4nS3r2cuWJq6jFg+/1+iG8YGftY=
+github.com/celestiaorg/go-square/v2 v2.3.3/go.mod h1:vY5RRv+qRmEVjPF6dAdr0dyLwKmTTDHHffENPQw8pUA=
 github.com/celestiaorg/utils v0.1.0 h1:WsP3O8jF7jKRgLNFmlDCwdThwOFMFxg0MnqhkLFVxPo=
 github.com/celestiaorg/utils v0.1.0/go.mod h1:vQTh7MHnvpIeCQZ2/Ph+w7K1R2UerDheZbgJEJD2hSU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/pkg/cmd/run_node_test.go
+++ b/pkg/cmd/run_node_test.go
@@ -85,7 +85,7 @@ func TestParseFlags(t *testing.T) {
 	executor, sequencer, dac, keyProvider, p2pClient, ds, stopDAHeightTicker := createTestComponents(context.Background(), t)
 	defer stopDAHeightTicker()
 
-	nodeConfig := rollconf.DefaultConfig
+	nodeConfig := rollconf.DefaultConfig()
 	nodeConfig.RootDir = t.TempDir()
 
 	newRunNodeCmd := newRunNodeCmd(t.Context(), executor, sequencer, dac, keyProvider, p2pClient, ds, nodeConfig)
@@ -164,7 +164,7 @@ func TestAggregatorFlagInvariants(t *testing.T) {
 		executor, sequencer, dac, keyProvider, p2pClient, ds, stopDAHeightTicker := createTestComponents(context.Background(), t)
 		defer stopDAHeightTicker()
 
-		nodeConfig := rollconf.DefaultConfig
+		nodeConfig := rollconf.DefaultConfig()
 		nodeConfig.RootDir = t.TempDir()
 
 		newRunNodeCmd := newRunNodeCmd(t.Context(), executor, sequencer, dac, keyProvider, p2pClient, ds, nodeConfig)
@@ -200,7 +200,7 @@ func TestDefaultAggregatorValue(t *testing.T) {
 			executor, sequencer, dac, keyProvider, p2pClient, ds, stopDAHeightTicker := createTestComponents(context.Background(), t)
 			defer stopDAHeightTicker()
 
-			nodeConfig := rollconf.DefaultConfig
+			nodeConfig := rollconf.DefaultConfig()
 			nodeConfig.RootDir = t.TempDir()
 
 			newRunNodeCmd := newRunNodeCmd(t.Context(), executor, sequencer, dac, keyProvider, p2pClient, ds, nodeConfig)
@@ -271,7 +271,7 @@ func TestSetupLogger(t *testing.T) {
 // TestCentralizedAddresses verifies that when centralized service flags are provided,
 // the configuration fields in nodeConfig are updated accordingly, ensuring that mocks are skipped.
 func TestCentralizedAddresses(t *testing.T) {
-	nodeConfig := rollconf.DefaultConfig
+	nodeConfig := rollconf.DefaultConfig()
 	nodeConfig.RootDir = t.TempDir()
 
 	args := []string{
@@ -319,7 +319,7 @@ func TestSignerRelativePathResolution(t *testing.T) {
 				assert.NoError(t, err)
 
 				// Configure node with relative signer path
-				nodeConfig := rollconf.DefaultConfig
+				nodeConfig := rollconf.DefaultConfig()
 				nodeConfig.RootDir = tmpDir
 				nodeConfig.Node.Aggregator = true
 				nodeConfig.Signer.SignerType = "file"
@@ -343,7 +343,7 @@ func TestSignerRelativePathResolution(t *testing.T) {
 				assert.NoError(t, err)
 
 				// Configure node with absolute signer path
-				nodeConfig := rollconf.DefaultConfig
+				nodeConfig := rollconf.DefaultConfig()
 				nodeConfig.RootDir = tmpDir
 				nodeConfig.Node.Aggregator = true
 				nodeConfig.Signer.SignerType = "file"
@@ -360,7 +360,7 @@ func TestSignerRelativePathResolution(t *testing.T) {
 				tmpDir := t.TempDir()
 
 				// Configure node with relative signer path that doesn't exist
-				nodeConfig := rollconf.DefaultConfig
+				nodeConfig := rollconf.DefaultConfig()
 				nodeConfig.RootDir = tmpDir
 				nodeConfig.Node.Aggregator = true
 				nodeConfig.Signer.SignerType = "file"
@@ -379,7 +379,7 @@ func TestSignerRelativePathResolution(t *testing.T) {
 				nonExistentPath := filepath.Join(tmpDir, "nonexistent")
 
 				// Configure node with absolute signer path that doesn't exist
-				nodeConfig := rollconf.DefaultConfig
+				nodeConfig := rollconf.DefaultConfig()
 				nodeConfig.RootDir = tmpDir
 				nodeConfig.Node.Aggregator = true
 				nodeConfig.Signer.SignerType = "file"
@@ -447,7 +447,7 @@ func TestStartNodeSignerPathResolution(t *testing.T) {
 				assert.NoError(t, err)
 
 				// Configure node with relative signer path
-				nodeConfig := rollconf.DefaultConfig
+				nodeConfig := rollconf.DefaultConfig()
 				nodeConfig.RootDir = tmpDir
 				nodeConfig.Node.Aggregator = true
 				nodeConfig.Signer.SignerType = "file"
@@ -464,7 +464,7 @@ func TestStartNodeSignerPathResolution(t *testing.T) {
 				tmpDir := t.TempDir()
 
 				// Configure node with relative signer path that doesn't exist
-				nodeConfig := rollconf.DefaultConfig
+				nodeConfig := rollconf.DefaultConfig()
 				nodeConfig.RootDir = tmpDir
 				nodeConfig.Node.Aggregator = true
 				nodeConfig.Signer.SignerType = "file"
@@ -489,7 +489,7 @@ func TestStartNodeSignerPathResolution(t *testing.T) {
 				assert.NoError(t, err)
 
 				// Configure node with absolute signer path
-				nodeConfig := rollconf.DefaultConfig
+				nodeConfig := rollconf.DefaultConfig()
 				nodeConfig.RootDir = tmpDir
 				nodeConfig.Node.Aggregator = true
 				nodeConfig.Signer.SignerType = "file"
@@ -629,7 +629,7 @@ func TestStartNodeErrors(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			nodeConfig := rollconf.DefaultConfig
+			nodeConfig := rollconf.DefaultConfig()
 			nodeConfig.RootDir = tmpDir
 
 			if tc.configModifier != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -16,18 +16,18 @@ import (
 
 func TestDefaultConfig(t *testing.T) {
 	// Test that default config has expected values
-	def := DefaultConfig
+	def := DefaultConfig()
 	def.RootDir = t.TempDir()
 
 	assert.Equal(t, "data", def.DBPath)
 	assert.Equal(t, false, def.Node.Aggregator)
 	assert.Equal(t, false, def.Node.Light)
-	assert.Equal(t, DefaultConfig.DA.Address, def.DA.Address)
+	assert.Equal(t, DefaultConfig().DA.Address, def.DA.Address)
 	assert.Equal(t, "", def.DA.AuthToken)
 	assert.Equal(t, float64(-1), def.DA.GasPrice)
 	assert.Equal(t, float64(0), def.DA.GasMultiplier)
 	assert.Equal(t, "", def.DA.SubmitOptions)
-	assert.Equal(t, "rollkit-headers", def.DA.Namespace)
+	assert.NotEmpty(t, def.DA.Namespace)
 	assert.Equal(t, 1*time.Second, def.Node.BlockTime.Duration)
 	assert.Equal(t, 6*time.Second, def.DA.BlockTime.Duration)
 	assert.Equal(t, uint64(0), def.DA.StartHeight)
@@ -53,34 +53,34 @@ func TestAddFlags(t *testing.T) {
 	persistentFlags := cmd.PersistentFlags()
 
 	// Test specific flags
-	assertFlagValue(t, flags, FlagDBPath, DefaultConfig.DBPath)
+	assertFlagValue(t, flags, FlagDBPath, DefaultConfig().DBPath)
 
 	// Node flags
-	assertFlagValue(t, flags, FlagAggregator, DefaultConfig.Node.Aggregator)
-	assertFlagValue(t, flags, FlagLight, DefaultConfig.Node.Light)
-	assertFlagValue(t, flags, FlagBlockTime, DefaultConfig.Node.BlockTime.Duration)
-	assertFlagValue(t, flags, FlagTrustedHash, DefaultConfig.Node.TrustedHash)
-	assertFlagValue(t, flags, FlagLazyAggregator, DefaultConfig.Node.LazyMode)
-	assertFlagValue(t, flags, FlagMaxPendingHeadersAndData, DefaultConfig.Node.MaxPendingHeadersAndData)
-	assertFlagValue(t, flags, FlagLazyBlockTime, DefaultConfig.Node.LazyBlockInterval.Duration)
+	assertFlagValue(t, flags, FlagAggregator, DefaultConfig().Node.Aggregator)
+	assertFlagValue(t, flags, FlagLight, DefaultConfig().Node.Light)
+	assertFlagValue(t, flags, FlagBlockTime, DefaultConfig().Node.BlockTime.Duration)
+	assertFlagValue(t, flags, FlagTrustedHash, DefaultConfig().Node.TrustedHash)
+	assertFlagValue(t, flags, FlagLazyAggregator, DefaultConfig().Node.LazyMode)
+	assertFlagValue(t, flags, FlagMaxPendingHeadersAndData, DefaultConfig().Node.MaxPendingHeadersAndData)
+	assertFlagValue(t, flags, FlagLazyBlockTime, DefaultConfig().Node.LazyBlockInterval.Duration)
 
 	// DA flags
-	assertFlagValue(t, flags, FlagDAAddress, DefaultConfig.DA.Address)
-	assertFlagValue(t, flags, FlagDAAuthToken, DefaultConfig.DA.AuthToken)
-	assertFlagValue(t, flags, FlagDABlockTime, DefaultConfig.DA.BlockTime.Duration)
-	assertFlagValue(t, flags, FlagDAGasPrice, DefaultConfig.DA.GasPrice)
-	assertFlagValue(t, flags, FlagDAGasMultiplier, DefaultConfig.DA.GasMultiplier)
-	assertFlagValue(t, flags, FlagDAStartHeight, DefaultConfig.DA.StartHeight)
-	assertFlagValue(t, flags, FlagDANamespace, DefaultConfig.DA.Namespace)
-	assertFlagValue(t, flags, FlagDASubmitOptions, DefaultConfig.DA.SubmitOptions)
-	assertFlagValue(t, flags, FlagDAMempoolTTL, DefaultConfig.DA.MempoolTTL)
-	assertFlagValue(t, flags, FlagDAMaxSubmitAttempts, DefaultConfig.DA.MaxSubmitAttempts)
+	assertFlagValue(t, flags, FlagDAAddress, DefaultConfig().DA.Address)
+	assertFlagValue(t, flags, FlagDAAuthToken, DefaultConfig().DA.AuthToken)
+	assertFlagValue(t, flags, FlagDABlockTime, DefaultConfig().DA.BlockTime.Duration)
+	assertFlagValue(t, flags, FlagDAGasPrice, DefaultConfig().DA.GasPrice)
+	assertFlagValue(t, flags, FlagDAGasMultiplier, DefaultConfig().DA.GasMultiplier)
+	assertFlagValue(t, flags, FlagDAStartHeight, DefaultConfig().DA.StartHeight)
+	assertFlagValue(t, flags, FlagDANamespace, DefaultConfig().DA.Namespace)
+	assertFlagValue(t, flags, FlagDASubmitOptions, DefaultConfig().DA.SubmitOptions)
+	assertFlagValue(t, flags, FlagDAMempoolTTL, DefaultConfig().DA.MempoolTTL)
+	assertFlagValue(t, flags, FlagDAMaxSubmitAttempts, DefaultConfig().DA.MaxSubmitAttempts)
 
 	// P2P flags
-	assertFlagValue(t, flags, FlagP2PListenAddress, DefaultConfig.P2P.ListenAddress)
-	assertFlagValue(t, flags, FlagP2PPeers, DefaultConfig.P2P.Peers)
-	assertFlagValue(t, flags, FlagP2PBlockedPeers, DefaultConfig.P2P.BlockedPeers)
-	assertFlagValue(t, flags, FlagP2PAllowedPeers, DefaultConfig.P2P.AllowedPeers)
+	assertFlagValue(t, flags, FlagP2PListenAddress, DefaultConfig().P2P.ListenAddress)
+	assertFlagValue(t, flags, FlagP2PPeers, DefaultConfig().P2P.Peers)
+	assertFlagValue(t, flags, FlagP2PBlockedPeers, DefaultConfig().P2P.BlockedPeers)
+	assertFlagValue(t, flags, FlagP2PAllowedPeers, DefaultConfig().P2P.AllowedPeers)
 
 	// Instrumentation flags
 	instrDef := DefaultInstrumentationConfig()
@@ -91,17 +91,17 @@ func TestAddFlags(t *testing.T) {
 	assertFlagValue(t, flags, FlagPprofListenAddr, instrDef.PprofListenAddr)
 
 	// Logging flags (in persistent flags)
-	assertFlagValue(t, persistentFlags, FlagLogLevel, DefaultConfig.Log.Level)
+	assertFlagValue(t, persistentFlags, FlagLogLevel, DefaultConfig().Log.Level)
 	assertFlagValue(t, persistentFlags, FlagLogFormat, "text")
 	assertFlagValue(t, persistentFlags, FlagLogTrace, false)
 
 	// Signer flags
 	assertFlagValue(t, flags, FlagSignerPassphrase, "")
 	assertFlagValue(t, flags, FlagSignerType, "file")
-	assertFlagValue(t, flags, FlagSignerPath, DefaultConfig.Signer.SignerPath)
+	assertFlagValue(t, flags, FlagSignerPath, DefaultConfig().Signer.SignerPath)
 
 	// RPC flags
-	assertFlagValue(t, flags, FlagRPCAddress, DefaultConfig.RPC.Address)
+	assertFlagValue(t, flags, FlagRPCAddress, DefaultConfig().RPC.Address)
 
 	// Count the number of flags we're explicitly checking
 	expectedFlagCount := 37 // Update this number if you add more flag checks above
@@ -197,7 +197,7 @@ signer:
 	assert.Equal(t, true, config.Node.Light, "Light should be set from flag")
 
 	// 4. Values not in flags or YAML should remain as default
-	assert.Equal(t, DefaultConfig.DA.BlockTime.Duration, config.DA.BlockTime.Duration, "DABlockTime should remain as default")
+	assert.Equal(t, DefaultConfig().DA.BlockTime.Duration, config.DA.BlockTime.Duration, "DABlockTime should remain as default")
 
 	// 5. Signer values should be set from flags
 	assert.Equal(t, "file", config.Signer.SignerType, "SignerType should be gotten from config")
@@ -339,10 +339,7 @@ func TestDAConfig_GetDataNamespace(t *testing.T) {
 			expectedNamespace: "namespace",
 		},
 		{
-			name:              "Both empty, use default value from default namespace",
-			dataNamespace:     "",
-			defaultNamespace:  "",
-			expectedNamespace: "rollkit-headers",
+			name: "Both empty",
 		},
 	}
 

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -81,7 +81,7 @@ func DefaultConfig() Config {
 func randString(length int) string {
 	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	result := make([]byte, length)
-	rng := rand.New(rand.NewSource(time.Now().Unix()))
+	rng := rand.New(rand.NewSource(time.Now().Unix())) // notlint:gosec // even half random is good enough here.
 	for i := range result {
 		result[i] = charset[rng.Intn(len(charset))]
 	}

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -81,7 +81,7 @@ func DefaultConfig() Config {
 func randString(length int) string {
 	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	result := make([]byte, length)
-	rng := rand.New(rand.NewSource(time.Now().Unix())) // notlint:gosec // even half random is good enough here.
+	rng := rand.New(rand.NewSource(time.Now().Unix())) //nolint:gosec // even half random is good enough here.
 	for i := range result {
 		result[i] = charset[rng.Intn(len(charset))]
 	}

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"math/rand"
 	"os"
 	"path/filepath"
 	"time"
@@ -36,41 +37,54 @@ func DefaultRootDirWithName(appName string) string {
 }
 
 // DefaultConfig keeps default values of NodeConfig
-var DefaultConfig = Config{
-	RootDir: DefaultRootDir,
-	DBPath:  "data",
-	P2P: P2PConfig{
-		ListenAddress: "/ip4/0.0.0.0/tcp/7676",
-		Peers:         "",
-	},
-	Node: NodeConfig{
-		Aggregator:        false,
-		BlockTime:         DurationWrapper{1 * time.Second},
-		LazyMode:          false,
-		LazyBlockInterval: DurationWrapper{60 * time.Second},
-		Light:             false,
-		TrustedHash:       "",
-	},
-	DA: DAConfig{
-		Address:           "http://localhost:7980",
-		BlockTime:         DurationWrapper{6 * time.Second},
-		GasPrice:          -1,
-		GasMultiplier:     0,
-		MaxSubmitAttempts: 30,
-		Namespace:         "rollkit-headers",
-		DataNamespace:     "",
-	},
-	Instrumentation: DefaultInstrumentationConfig(),
-	Log: LogConfig{
-		Level:  "info",
-		Format: "text",
-		Trace:  false,
-	},
-	Signer: SignerConfig{
-		SignerType: "file",
-		SignerPath: "config",
-	},
-	RPC: RPCConfig{
-		Address: "127.0.0.1:7331",
-	},
+func DefaultConfig() Config {
+	return Config{
+		RootDir: DefaultRootDir,
+		DBPath:  "data",
+		P2P: P2PConfig{
+			ListenAddress: "/ip4/0.0.0.0/tcp/7676",
+			Peers:         "",
+		},
+		Node: NodeConfig{
+			Aggregator:        false,
+			BlockTime:         DurationWrapper{1 * time.Second},
+			LazyMode:          false,
+			LazyBlockInterval: DurationWrapper{60 * time.Second},
+			Light:             false,
+			TrustedHash:       "",
+		},
+		DA: DAConfig{
+			Address:           "http://localhost:7980",
+			BlockTime:         DurationWrapper{6 * time.Second},
+			GasPrice:          -1,
+			GasMultiplier:     0,
+			MaxSubmitAttempts: 30,
+			Namespace:         randString(10),
+			DataNamespace:     "",
+		},
+		Instrumentation: DefaultInstrumentationConfig(),
+		Log: LogConfig{
+			Level:  "info",
+			Format: "text",
+			Trace:  false,
+		},
+		Signer: SignerConfig{
+			SignerType: "file",
+			SignerPath: "config",
+		},
+		RPC: RPCConfig{
+			Address: "127.0.0.1:7331",
+		},
+	}
+}
+
+func randString(length int) string {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	result := make([]byte, length)
+	rng := rand.New(rand.NewSource(time.Now().Unix()))
+	for i := range result {
+		result[i] = charset[rng.Intn(len(charset))]
+	}
+
+	return string(result)
 }

--- a/pkg/config/yaml_test.go
+++ b/pkg/config/yaml_test.go
@@ -16,9 +16,9 @@ func TestYamlConfigOperations(t *testing.T) {
 		{
 			name: "Write and read custom config values",
 			setup: func(t *testing.T, dir string) *Config {
-				cfg := DefaultConfig
+				cfg := DefaultConfig()
 				cfg.RootDir = dir
-				cfg.P2P.ListenAddress = DefaultConfig.P2P.ListenAddress
+				cfg.P2P.ListenAddress = DefaultConfig().P2P.ListenAddress
 				cfg.P2P.Peers = "seed1.example.com:26656,seed2.example.com:26656"
 
 				require.NoError(t, cfg.SaveAsYaml())
@@ -26,14 +26,14 @@ func TestYamlConfigOperations(t *testing.T) {
 				return &cfg
 			},
 			validate: func(t *testing.T, cfg *Config) {
-				require.Equal(t, DefaultConfig.P2P.ListenAddress, cfg.P2P.ListenAddress)
+				require.Equal(t, DefaultConfig().P2P.ListenAddress, cfg.P2P.ListenAddress)
 				require.Equal(t, "seed1.example.com:26656,seed2.example.com:26656", cfg.P2P.Peers)
 			},
 		},
 		{
 			name: "Initialize default config values",
 			setup: func(t *testing.T, dir string) *Config {
-				cfg := DefaultConfig
+				cfg := DefaultConfig()
 				cfg.RootDir = dir
 
 				require.NoError(t, cfg.SaveAsYaml())
@@ -41,8 +41,8 @@ func TestYamlConfigOperations(t *testing.T) {
 				return &cfg
 			},
 			validate: func(t *testing.T, cfg *Config) {
-				require.Equal(t, DefaultConfig.P2P.ListenAddress, cfg.P2P.ListenAddress)
-				require.Equal(t, DefaultConfig.P2P.Peers, cfg.P2P.Peers)
+				require.Equal(t, DefaultConfig().P2P.ListenAddress, cfg.P2P.ListenAddress)
+				require.Equal(t, DefaultConfig().P2P.Peers, cfg.P2P.Peers)
 			},
 		},
 	}

--- a/pkg/p2p/client_test.go
+++ b/pkg/p2p/client_test.go
@@ -29,7 +29,7 @@ func TestNewClientWithHost(t *testing.T) {
 	assert := assert.New(t)
 
 	// Common setup
-	conf := config.DefaultConfig
+	conf := config.DefaultConfig()
 	conf.RootDir = t.TempDir()
 	nodeKey, err := key.LoadOrGenNodeKey(filepath.Join(conf.RootDir, "config", "node_key.json"))
 	require.NoError(err)
@@ -92,7 +92,7 @@ func TestClientStartup(t *testing.T) {
 	nodeKey, err := key.LoadOrGenNodeKey(filepath.Join(tempDir, "config", "node_key.json"))
 	assert.NoError(err)
 
-	defaultConfig := config.DefaultConfig
+	defaultConfig := config.DefaultConfig()
 
 	testCases := []struct {
 		desc string
@@ -286,7 +286,7 @@ func TestClientInfoMethods(t *testing.T) {
 
 	tempDir := t.TempDir()
 	ClientInitFiles(t, tempDir)
-	conf := config.DefaultConfig
+	conf := config.DefaultConfig()
 	conf.RootDir = tempDir
 
 	mn := mocknet.New()

--- a/pkg/rpc/client/client_test.go
+++ b/pkg/rpc/client/client_test.go
@@ -35,7 +35,7 @@ func setupTestServer(t *testing.T, mockStore *mocks.MockStore, mockP2P *mocks.Mo
 	healthServer := server.NewHealthServer()
 
 	// Create config server with test config
-	testConfig := config.DefaultConfig
+	testConfig := config.DefaultConfig()
 	testConfig.DA.Namespace = "test-headers"
 	configServer := server.NewConfigServer(testConfig, nil, logger)
 

--- a/pkg/rpc/example/example.go
+++ b/pkg/rpc/example/example.go
@@ -20,7 +20,7 @@ func StartStoreServer(s store.Store, address string, logger zerolog.Logger) {
 	// Create and start the server
 	// Start RPC server
 	rpcAddr := fmt.Sprintf("%s:%d", "localhost", 8080)
-	cfg := config.DefaultConfig
+	cfg := config.DefaultConfig()
 	handler, err := server.NewServiceHandler(s, nil, nil, logger, cfg)
 	if err != nil {
 		panic(err)
@@ -80,7 +80,7 @@ func ExampleServer(s store.Store) {
 
 	// Start RPC server
 	rpcAddr := fmt.Sprintf("%s:%d", "localhost", 8080)
-	cfg := config.DefaultConfig
+	cfg := config.DefaultConfig()
 	handler, err := server.NewServiceHandler(s, nil, nil, logger, cfg)
 	if err != nil {
 		panic(err)

--- a/pkg/rpc/server/server_test.go
+++ b/pkg/rpc/server/server_test.go
@@ -376,7 +376,7 @@ func TestHealthLiveEndpoint(t *testing.T) {
 
 	// Create the service handler
 	logger := zerolog.Nop()
-	testConfig := config.DefaultConfig
+	testConfig := config.DefaultConfig()
 	handler, err := NewServiceHandler(mockStore, mockP2PManager, nil, logger, testConfig)
 	assert.NoError(err)
 	assert.NotNil(handler)

--- a/pkg/sync/sync_service_test.go
+++ b/pkg/sync/sync_service_test.go
@@ -41,7 +41,7 @@ func TestHeaderSyncServiceRestart(t *testing.T) {
 		InitialHeight:   1,
 		ProposerAddress: proposerAddr,
 	}
-	conf := config.DefaultConfig
+	conf := config.DefaultConfig()
 	conf.RootDir = t.TempDir()
 	nodeKey, err := key.LoadOrGenNodeKey(filepath.Dir(conf.ConfigPath()))
 	require.NoError(t, err)

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -91,6 +91,8 @@ github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXe
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/celestiaorg/go-header v0.7.2 h1:Jw01iBKnodfsILzynDCU3C11xurpoBt5SI9lgyKHJc0=
 github.com/celestiaorg/go-header v0.7.2/go.mod h1:eX9iTSPthVEAlEDLux40ZT/olXPGhpxHd+mEzJeDhd0=
+github.com/celestiaorg/go-square/v2 v2.3.3 h1:vhu6Lt39km19Q/Jk4nS3r2cuWJq6jFg+/1+iG8YGftY=
+github.com/celestiaorg/go-square/v2 v2.3.3/go.mod h1:vY5RRv+qRmEVjPF6dAdr0dyLwKmTTDHHffENPQw8pUA=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=


### PR DESCRIPTION
Update the default namespace to a random string on init to avoid collisions.
Validate the namespace using go-square lib, as suggested by node team.

Users should always have a namespace for their chain, but having a random one, improve usability and testing while making sure users won't by mistake all publish to the same namespace.