### PR TITLE
refactor(core)!: remove `PrepareNamespace`

### DIFF
--- a/apps/evm/single/cmd/run.go
+++ b/apps/evm/single/cmd/run.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
 	"path/filepath"
 
@@ -30,27 +29,27 @@ var RunCmd = &cobra.Command{
 	Aliases: []string{"node", "run"},
 	Short:   "Run the evolve node with EVM execution client",
 	RunE: func(cmd *cobra.Command, args []string) error {
-    executor, err := createExecutionClient(cmd)
-    if err != nil {
-        return err
-    }
+		executor, err := createExecutionClient(cmd)
+		if err != nil {
+			return err
+		}
 
-    nodeConfig, err := rollcmd.ParseConfig(cmd)
-    if err != nil {
-        return err
-    }
+		nodeConfig, err := rollcmd.ParseConfig(cmd)
+		if err != nil {
+			return err
+		}
 
-    logger := rollcmd.SetupLogger(nodeConfig.Log)
+		logger := rollcmd.SetupLogger(nodeConfig.Log)
 
-    // Attach logger to the EVM engine client if available
-    if ec, ok := executor.(*evm.EngineClient); ok {
-        ec.SetLogger(logger.With().Str("module", "engine_client").Logger())
-    }
+		// Attach logger to the EVM engine client if available
+		if ec, ok := executor.(*evm.EngineClient); ok {
+			ec.SetLogger(logger.With().Str("module", "engine_client").Logger())
+		}
 
-		headerNamespace := da.PrepareNamespace([]byte(nodeConfig.DA.GetNamespace()))
-		dataNamespace := da.PrepareNamespace([]byte(nodeConfig.DA.GetDataNamespace()))
+		headerNamespace := da.NamespaceFromString(nodeConfig.DA.GetNamespace())
+		dataNamespace := da.NamespaceFromString(nodeConfig.DA.GetDataNamespace())
 
-		logger.Info().Str("headerNamespace", hex.EncodeToString(headerNamespace)).Str("dataNamespace", hex.EncodeToString(dataNamespace)).Msg("namespaces")
+		logger.Info().Str("headerNamespace", headerNamespace.HexString()).Str("dataNamespace", dataNamespace.HexString()).Msg("namespaces")
 
 		daJrpc, err := jsonrpc.NewClient(context.Background(), logger, nodeConfig.DA.Address, nodeConfig.DA.AuthToken, nodeConfig.DA.GasPrice, nodeConfig.DA.GasMultiplier)
 		if err != nil {

--- a/apps/grpc/single/cmd/run.go
+++ b/apps/grpc/single/cmd/run.go
@@ -1,13 +1,12 @@
 package cmd
 
 import (
-	"encoding/hex"
 	"fmt"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
 
-	coreda "github.com/evstack/ev-node/core/da"
+	"github.com/evstack/ev-node/core/da"
 	"github.com/evstack/ev-node/core/execution"
 	"github.com/evstack/ev-node/da/jsonrpc"
 	executiongrpc "github.com/evstack/ev-node/execution/grpc"
@@ -47,10 +46,10 @@ The execution client must implement the Evolve execution gRPC interface.`,
 
 		logger := rollcmd.SetupLogger(nodeConfig.Log)
 
-		headerNamespace := coreda.PrepareNamespace([]byte(nodeConfig.DA.GetNamespace()))
-		dataNamespace := coreda.PrepareNamespace([]byte(nodeConfig.DA.GetDataNamespace()))
+		headerNamespace := da.NamespaceFromString(nodeConfig.DA.GetNamespace())
+		dataNamespace := da.NamespaceFromString(nodeConfig.DA.GetDataNamespace())
 
-		logger.Info().Str("headerNamespace", hex.EncodeToString(headerNamespace)).Str("dataNamespace", hex.EncodeToString(dataNamespace)).Msg("namespaces")
+		logger.Info().Str("headerNamespace", headerNamespace.HexString()).Str("dataNamespace", dataNamespace.HexString()).Msg("namespaces")
 
 		// Create DA client
 		daJrpc, err := jsonrpc.NewClient(cmd.Context(), logger, nodeConfig.DA.Address, nodeConfig.DA.AuthToken, nodeConfig.DA.GasPrice, nodeConfig.DA.GasMultiplier)

--- a/apps/testapp/cmd/run.go
+++ b/apps/testapp/cmd/run.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
 	"path/filepath"
 
@@ -47,10 +46,10 @@ var RunCmd = &cobra.Command{
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		headerNamespace := da.PrepareNamespace([]byte(nodeConfig.DA.GetNamespace()))
-		dataNamespace := da.PrepareNamespace([]byte(nodeConfig.DA.GetDataNamespace()))
+		headerNamespace := da.NamespaceFromString(nodeConfig.DA.GetNamespace())
+		dataNamespace := da.NamespaceFromString(nodeConfig.DA.GetDataNamespace())
 
-		logger.Info().Str("headerNamespace", hex.EncodeToString(headerNamespace)).Str("dataNamespace", hex.EncodeToString(dataNamespace)).Msg("namespaces")
+		logger.Info().Str("headerNamespace", headerNamespace.HexString()).Str("dataNamespace", dataNamespace.HexString()).Msg("namespaces")
 
 		daJrpc, err := jsonrpc.NewClient(ctx, logger, nodeConfig.DA.Address, nodeConfig.DA.AuthToken, nodeConfig.DA.GasPrice, nodeConfig.DA.GasMultiplier)
 		if err != nil {

--- a/block/internal/submitting/da_submitter.go
+++ b/block/internal/submitting/da_submitter.go
@@ -199,7 +199,7 @@ func (s *DASubmitter) SubmitHeaders(ctx context.Context, cache cache.Manager) er
 			}
 		},
 		"header",
-		[]byte(s.config.DA.GetNamespace()),
+		s.config.DA.GetNamespace(),
 		[]byte(s.config.DA.SubmitOptions),
 		cache,
 	)
@@ -242,7 +242,7 @@ func (s *DASubmitter) SubmitData(ctx context.Context, cache cache.Manager, signe
 			}
 		},
 		"data",
-		[]byte(s.config.DA.GetDataNamespace()),
+		s.config.DA.GetDataNamespace(),
 		[]byte(s.config.DA.SubmitOptions),
 		cache,
 	)
@@ -312,7 +312,7 @@ func submitToDA[T any](
 	marshalFn func(T) ([]byte, error),
 	postSubmit func([]T, *coreda.ResultSubmit, float64),
 	itemType string,
-	namespace []byte,
+	namespace string,
 	options []byte,
 	cache cache.Manager,
 ) error {

--- a/block/internal/submitting/da_submitter_mocks_test.go
+++ b/block/internal/submitting/da_submitter_mocks_test.go
@@ -45,7 +45,7 @@ func TestSubmitToDA_MempoolRetry_IncreasesGasAndSucceeds(t *testing.T) {
 
 	// First attempt returns a mempool-related error (mapped to StatusNotIncludedInBlock)
 	// Expect gasPrice=1.0
-	ns := []byte("ns")
+	ns := "ns"
 	opts := []byte("opts")
 	// capture gas prices used
 	var usedGas []float64
@@ -99,7 +99,7 @@ func TestSubmitToDA_UnknownError_RetriesSameGasThenSucceeds(t *testing.T) {
 	// Initial gas price comes from config (set below), so DA.GasPrice is not called
 	mockDA.On("GasMultiplier", mock.Anything).Return(3.0, nil).Once()
 
-	ns := []byte("ns")
+	ns := "ns"
 	opts := []byte("opts")
 	var usedGas []float64
 
@@ -147,7 +147,7 @@ func TestSubmitToDA_TooBig_HalvesBatch(t *testing.T) {
 	// Use fixed gas from config to simplify
 	mockDA.On("GasMultiplier", mock.Anything).Return(2.0, nil).Once()
 
-	ns := []byte("ns")
+	ns := "ns"
 	opts := []byte("opts")
 	// record sizes of batches sent to DA
 	var batchSizes []int
@@ -202,7 +202,7 @@ func TestSubmitToDA_SentinelNoGas_PreservesGasAcrossRetries(t *testing.T) {
 	// GasMultiplier is still called once, but should not affect gas when sentinel is used
 	mockDA.On("GasMultiplier", mock.Anything).Return(10.0, nil).Once()
 
-	ns := []byte("ns")
+	ns := "ns"
 	opts := []byte("opts")
 	var usedGas []float64
 
@@ -249,7 +249,7 @@ func TestSubmitToDA_PartialSuccess_AdvancesWindow(t *testing.T) {
 	mockDA := mocks.NewMockDA(t)
 	mockDA.On("GasMultiplier", mock.Anything).Return(2.0, nil).Once()
 
-	ns := []byte("ns")
+	ns := "ns"
 	opts := []byte("opts")
 	// track how many items postSubmit sees across attempts
 	var totalSubmitted int

--- a/block/internal/submitting/da_submitter_mocks_test.go
+++ b/block/internal/submitting/da_submitter_mocks_test.go
@@ -46,8 +46,7 @@ func TestSubmitToDA_MempoolRetry_IncreasesGasAndSucceeds(t *testing.T) {
 	// First attempt returns a mempool-related error (mapped to StatusNotIncludedInBlock)
 	// Expect gasPrice=1.0
 
-	ns := "ns"
-	nsBz := coreda.NamespaceFromString(ns).Bytes()
+	nsBz := coreda.NamespaceFromString("ns").Bytes()
 
 	opts := []byte("opts")
 	// capture gas prices used
@@ -84,7 +83,7 @@ func TestSubmitToDA_MempoolRetry_IncreasesGasAndSucceeds(t *testing.T) {
 		marshalString,
 		func(_ []string, _ *coreda.ResultSubmit, _ float64) {},
 		"item",
-		ns,
+		nsBz,
 		opts,
 		nil,
 	)
@@ -102,8 +101,7 @@ func TestSubmitToDA_UnknownError_RetriesSameGasThenSucceeds(t *testing.T) {
 	// Initial gas price comes from config (set below), so DA.GasPrice is not called
 	mockDA.On("GasMultiplier", mock.Anything).Return(3.0, nil).Once()
 
-	ns := "ns"
-	nsBz := coreda.NamespaceFromString(ns).Bytes()
+	nsBz := coreda.NamespaceFromString("ns").Bytes()
 
 	opts := []byte("opts")
 	var usedGas []float64
@@ -136,7 +134,7 @@ func TestSubmitToDA_UnknownError_RetriesSameGasThenSucceeds(t *testing.T) {
 		marshalString,
 		func(_ []string, _ *coreda.ResultSubmit, _ float64) {},
 		"item",
-		ns,
+		nsBz,
 		opts,
 		nil,
 	)
@@ -152,8 +150,7 @@ func TestSubmitToDA_TooBig_HalvesBatch(t *testing.T) {
 	// Use fixed gas from config to simplify
 	mockDA.On("GasMultiplier", mock.Anything).Return(2.0, nil).Once()
 
-	ns := "ns"
-	nsBz := coreda.NamespaceFromString(ns).Bytes()
+	nsBz := coreda.NamespaceFromString("ns").Bytes()
 
 	opts := []byte("opts")
 	// record sizes of batches sent to DA
@@ -193,7 +190,7 @@ func TestSubmitToDA_TooBig_HalvesBatch(t *testing.T) {
 		marshalString,
 		func(_ []string, _ *coreda.ResultSubmit, _ float64) {},
 		"item",
-		ns,
+		nsBz,
 		opts,
 		nil,
 	)
@@ -209,8 +206,7 @@ func TestSubmitToDA_SentinelNoGas_PreservesGasAcrossRetries(t *testing.T) {
 	// GasMultiplier is still called once, but should not affect gas when sentinel is used
 	mockDA.On("GasMultiplier", mock.Anything).Return(10.0, nil).Once()
 
-	ns := "ns"
-	nsBz := coreda.NamespaceFromString(ns).Bytes()
+	nsBz := coreda.NamespaceFromString("ns").Bytes()
 
 	opts := []byte("opts")
 	var usedGas []float64
@@ -243,7 +239,7 @@ func TestSubmitToDA_SentinelNoGas_PreservesGasAcrossRetries(t *testing.T) {
 		marshalString,
 		func(_ []string, _ *coreda.ResultSubmit, _ float64) {},
 		"item",
-		ns,
+		nsBz,
 		opts,
 		nil,
 	)
@@ -258,8 +254,7 @@ func TestSubmitToDA_PartialSuccess_AdvancesWindow(t *testing.T) {
 	mockDA := mocks.NewMockDA(t)
 	mockDA.On("GasMultiplier", mock.Anything).Return(2.0, nil).Once()
 
-	ns := "ns"
-	nsBz := coreda.NamespaceFromString(ns).Bytes()
+	nsBz := coreda.NamespaceFromString("ns").Bytes()
 
 	opts := []byte("opts")
 	// track how many items postSubmit sees across attempts
@@ -284,7 +279,7 @@ func TestSubmitToDA_PartialSuccess_AdvancesWindow(t *testing.T) {
 		marshalString,
 		func(submitted []string, _ *coreda.ResultSubmit, _ float64) { totalSubmitted += len(submitted) },
 		"item",
-		ns,
+		nsBz,
 		opts,
 		nil,
 	)

--- a/block/internal/syncing/da_retriever.go
+++ b/block/internal/syncing/da_retriever.go
@@ -108,7 +108,7 @@ func (r *DARetriever) fetchBlobs(ctx context.Context, daHeight uint64) (coreda.R
 	headerRes := types.RetrieveWithHelpers(ctx, r.da, r.logger, daHeight, headerNamespace)
 
 	// If namespaces are the same, return header result
-	if string(headerNamespace) == string(dataNamespace) {
+	if headerNamespace == dataNamespace {
 		return headerRes, r.validateBlobResponse(headerRes, daHeight)
 	}
 

--- a/block/internal/syncing/da_retriever.go
+++ b/block/internal/syncing/da_retriever.go
@@ -101,8 +101,8 @@ func (r *DARetriever) fetchBlobs(ctx context.Context, daHeight uint64) (coreda.R
 	defer cancel()
 
 	// Get namespaces
-	headerNamespace := []byte(r.config.DA.GetNamespace())
-	dataNamespace := []byte(r.config.DA.GetDataNamespace())
+	headerNamespace := r.config.DA.GetNamespace()
+	dataNamespace := r.config.DA.GetDataNamespace()
 
 	// Retrieve from both namespaces
 	headerRes := types.RetrieveWithHelpers(ctx, r.da, r.logger, daHeight, headerNamespace)

--- a/block/internal/syncing/da_retriever.go
+++ b/block/internal/syncing/da_retriever.go
@@ -29,10 +29,13 @@ const (
 type DARetriever struct {
 	da      coreda.DA
 	cache   cache.Manager
-	config  config.Config
 	genesis genesis.Genesis
 	options common.BlockOptions
 	logger  zerolog.Logger
+
+	// calculate namespaces bytes once and reuse them
+	namespaceBz     []byte
+	namespaceDataBz []byte
 }
 
 // NewDARetriever creates a new DA retriever
@@ -45,12 +48,13 @@ func NewDARetriever(
 	logger zerolog.Logger,
 ) *DARetriever {
 	return &DARetriever{
-		da:      da,
-		cache:   cache,
-		config:  config,
-		genesis: genesis,
-		options: options,
-		logger:  logger.With().Str("component", "da_retriever").Logger(),
+		da:              da,
+		cache:           cache,
+		genesis:         genesis,
+		options:         options,
+		logger:          logger.With().Str("component", "da_retriever").Logger(),
+		namespaceBz:     coreda.NamespaceFromString(config.DA.GetNamespace()).Bytes(),
+		namespaceDataBz: coreda.NamespaceFromString(config.DA.GetDataNamespace()).Bytes(),
 	}
 }
 
@@ -100,19 +104,15 @@ func (r *DARetriever) fetchBlobs(ctx context.Context, daHeight uint64) (coreda.R
 	ctx, cancel := context.WithTimeout(ctx, dAFetcherTimeout)
 	defer cancel()
 
-	// Get namespaces
-	headerNamespace := r.config.DA.GetNamespace()
-	dataNamespace := r.config.DA.GetDataNamespace()
-
 	// Retrieve from both namespaces
-	headerRes := types.RetrieveWithHelpers(ctx, r.da, r.logger, daHeight, headerNamespace)
+	headerRes := types.RetrieveWithHelpers(ctx, r.da, r.logger, daHeight, r.namespaceBz)
 
 	// If namespaces are the same, return header result
-	if headerNamespace == dataNamespace {
+	if bytes.Equal(r.namespaceBz, r.namespaceDataBz) {
 		return headerRes, r.validateBlobResponse(headerRes, daHeight)
 	}
 
-	dataRes := types.RetrieveWithHelpers(ctx, r.da, r.logger, daHeight, dataNamespace)
+	dataRes := types.RetrieveWithHelpers(ctx, r.da, r.logger, daHeight, r.namespaceDataBz)
 
 	// Validate responses
 	headerErr := r.validateBlobResponse(headerRes, daHeight)

--- a/core/da/namespace.go
+++ b/core/da/namespace.go
@@ -10,6 +10,8 @@ import (
 // Implemented in accordance to https://celestiaorg.github.io/celestia-app/namespace.html
 
 const (
+	// NamespaceVersionIndex is the index of the namespace version in the byte slice
+	NamespaceVersionIndex = 0
 	// NamespaceVersionSize is the size of the namespace version in bytes
 	NamespaceVersionSize = 1
 	// NamespaceIDSize is the size of the namespace ID in bytes
@@ -37,8 +39,8 @@ type Namespace struct {
 // Bytes returns the namespace as a byte slice
 func (n Namespace) Bytes() []byte {
 	result := make([]byte, NamespaceSize)
-	result[0] = n.Version
-	copy(result[1:], n.ID[:])
+	result[NamespaceVersionIndex] = n.Version
+	copy(result[NamespaceVersionSize:], n.ID[:])
 	return result
 }
 
@@ -49,7 +51,7 @@ func (n Namespace) IsValidForVersion0() bool {
 		return false
 	}
 
-	for i := 0; i < NamespaceVersionZeroPrefixSize; i++ {
+	for i := range NamespaceVersionZeroPrefixSize {
 		if n.ID[i] != 0 {
 			return false
 		}
@@ -84,9 +86,9 @@ func NamespaceFromBytes(b []byte) (*Namespace, error) {
 	}
 
 	ns := &Namespace{
-		Version: b[0],
+		Version: b[NamespaceVersionIndex],
 	}
-	copy(ns.ID[:], b[1:])
+	copy(ns.ID[:], b[NamespaceVersionSize:])
 
 	// Validate if it's version 0
 	if ns.Version == NamespaceVersionZero && !ns.IsValidForVersion0() {

--- a/core/da/namespace.go
+++ b/core/da/namespace.go
@@ -125,20 +125,3 @@ func ParseHexNamespace(hexStr string) (*Namespace, error) {
 
 	return NamespaceFromBytes(b)
 }
-
-// PrepareNamespace converts a namespace identifier (string or bytes) into a proper Celestia namespace
-// This is the main function to be used when preparing namespaces for DA operations
-func PrepareNamespace(identifier []byte) []byte {
-	// If the identifier is already a valid namespace (29 bytes), validate and return it
-	if len(identifier) == NamespaceSize {
-		ns, err := NamespaceFromBytes(identifier)
-		if err == nil {
-			return ns.Bytes()
-		}
-		// If it's not a valid namespace, treat it as a string identifier
-	}
-
-	// Convert the identifier to a string and create a namespace from it
-	ns := NamespaceFromString(string(identifier))
-	return ns.Bytes()
-}

--- a/core/da/namespace_test.go
+++ b/core/da/namespace_test.go
@@ -64,7 +64,7 @@ func TestNamespaceV0Creation(t *testing.T) {
 				}
 
 				// Verify first 18 bytes of ID are zeros
-				for i := 0; i < NamespaceVersionZeroPrefixSize; i++ {
+				for i := range NamespaceVersionZeroPrefixSize {
 					if ns.ID[i] != byte(0) {
 						t.Errorf("First 18 bytes should be zero, but byte %d is %d", i, ns.ID[i])
 					}

--- a/core/da/namespace_test.go
+++ b/core/da/namespace_test.go
@@ -42,7 +42,7 @@ func TestNamespaceV0Creation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ns, err := NewNamespaceV0(tt.data)
-			
+
 			if tt.expectError {
 				if err == nil {
 					t.Errorf("%s: expected error but got nil", tt.description)
@@ -57,19 +57,19 @@ func TestNamespaceV0Creation(t *testing.T) {
 				if ns == nil {
 					t.Fatal("expected non-nil namespace but got nil")
 				}
-				
+
 				// Verify version is 0
 				if ns.Version != NamespaceVersionZero {
 					t.Errorf("Version should be 0, got %d", ns.Version)
 				}
-				
+
 				// Verify first 18 bytes of ID are zeros
 				for i := 0; i < NamespaceVersionZeroPrefixSize; i++ {
 					if ns.ID[i] != byte(0) {
 						t.Errorf("First 18 bytes should be zero, but byte %d is %d", i, ns.ID[i])
 					}
 				}
-				
+
 				// Verify data is in the last 10 bytes
 				expectedData := make([]byte, NamespaceVersionZeroDataSize)
 				copy(expectedData, tt.data)
@@ -77,12 +77,12 @@ func TestNamespaceV0Creation(t *testing.T) {
 				if !bytes.Equal(expectedData, actualData) {
 					t.Errorf("Data should match in last 10 bytes, expected %v, got %v", expectedData, actualData)
 				}
-				
+
 				// Verify total size
 				if len(ns.Bytes()) != NamespaceSize {
 					t.Errorf("Total namespace size should be 29 bytes, got %d", len(ns.Bytes()))
 				}
-				
+
 				// Verify it's valid for version 0
 				if !ns.IsValidForVersion0() {
 					t.Error("Should be valid for version 0")
@@ -128,7 +128,7 @@ func TestNamespaceFromBytes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ns, err := NamespaceFromBytes(tt.input)
-			
+
 			if tt.expectError {
 				if err == nil {
 					t.Errorf("%s: expected error but got nil", tt.description)
@@ -170,7 +170,7 @@ func TestNamespaceFromString(t *testing.T) {
 				if len(ns.Bytes()) != NamespaceSize {
 					t.Errorf("expected namespace size %d, got %d", NamespaceSize, len(ns.Bytes()))
 				}
-				
+
 				// The hash should be deterministic
 				ns2 := NamespaceFromString("rollkit-headers")
 				if !bytes.Equal(ns.Bytes(), ns2.Bytes()) {
@@ -191,7 +191,7 @@ func TestNamespaceFromString(t *testing.T) {
 				if len(ns.Bytes()) != NamespaceSize {
 					t.Errorf("expected namespace size %d, got %d", NamespaceSize, len(ns.Bytes()))
 				}
-				
+
 				// Different strings should produce different namespaces
 				ns2 := NamespaceFromString("rollkit-headers")
 				if bytes.Equal(ns.Bytes(), ns2.Bytes()) {
@@ -227,89 +227,12 @@ func TestNamespaceFromString(t *testing.T) {
 	}
 }
 
-func TestPrepareNamespace(t *testing.T) {
-	tests := []struct {
-		name        string
-		input       []byte
-		description string
-		verify      func(t *testing.T, result []byte)
-	}{
-		{
-			name:        "string identifier",
-			input:       []byte("rollkit-headers"),
-			description: "Should convert string to valid namespace",
-			verify: func(t *testing.T, result []byte) {
-				if len(result) != NamespaceSize {
-					t.Errorf("expected result size %d, got %d", NamespaceSize, len(result))
-				}
-				if result[0] != byte(0) {
-					t.Errorf("Should be version 0, got %d", result[0])
-				}
-				
-				// Verify first 18 bytes of ID are zeros
-				for i := 1; i <= 18; i++ {
-					if result[i] != byte(0) {
-						t.Errorf("First 18 bytes of ID should be zero, but byte %d is %d", i, result[i])
-					}
-				}
-			},
-		},
-		{
-			name:        "already valid namespace",
-			input:       append([]byte{0}, append(make([]byte, 18), []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}...)...),
-			description: "Should return already valid namespace unchanged",
-			verify: func(t *testing.T, result []byte) {
-				if len(result) != NamespaceSize {
-					t.Errorf("expected result size %d, got %d", NamespaceSize, len(result))
-				}
-				if result[0] != byte(0) {
-					t.Errorf("expected version 0, got %d", result[0])
-				}
-				// Should pass through unchanged
-				expected := append([]byte{0}, append(make([]byte, 18), []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}...)...)
-				if !bytes.Equal(expected, result) {
-					t.Errorf("Should pass through unchanged, expected %v, got %v", expected, result)
-				}
-			},
-		},
-		{
-			name:        "invalid 29-byte input",
-			input:       append([]byte{0}, append([]byte{1}, make([]byte, 27)...)...), // Invalid: non-zero in prefix
-			description: "Should treat invalid 29-byte input as string and hash it",
-			verify: func(t *testing.T, result []byte) {
-				if len(result) != NamespaceSize {
-					t.Errorf("expected result size %d, got %d", NamespaceSize, len(result))
-				}
-				if result[0] != byte(0) {
-					t.Errorf("expected version 0, got %d", result[0])
-				}
-				
-				// Should be hashed, not passed through
-				invalidNs := append([]byte{0}, append([]byte{1}, make([]byte, 27)...)...)
-				if bytes.Equal(invalidNs, result) {
-					t.Error("Should not pass through invalid namespace")
-				}
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := PrepareNamespace(tt.input)
-			if result == nil {
-				t.Fatal("expected non-nil result but got nil")
-			}
-			tt.verify(t, result)
-		})
-	}
-}
-
 func TestHexStringConversion(t *testing.T) {
 	ns, err := NewNamespaceV0([]byte{1, 2, 3, 4, 5})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	
+
 	// Test HexString
 	hexStr := ns.HexString()
 	if len(hexStr) <= 2 {
@@ -318,7 +241,7 @@ func TestHexStringConversion(t *testing.T) {
 	if hexStr[:2] != "0x" {
 		t.Errorf("Should have 0x prefix, got %s", hexStr[:2])
 	}
-	
+
 	// Test ParseHexNamespace
 	parsed, err := ParseHexNamespace(hexStr)
 	if err != nil {
@@ -327,7 +250,7 @@ func TestHexStringConversion(t *testing.T) {
 	if !bytes.Equal(ns.Bytes(), parsed.Bytes()) {
 		t.Error("Should round-trip through hex")
 	}
-	
+
 	// Test without 0x prefix
 	parsed2, err := ParseHexNamespace(hexStr[2:])
 	if err != nil {
@@ -336,13 +259,13 @@ func TestHexStringConversion(t *testing.T) {
 	if !bytes.Equal(ns.Bytes(), parsed2.Bytes()) {
 		t.Error("Should work without 0x prefix")
 	}
-	
+
 	// Test invalid hex
 	_, err = ParseHexNamespace("invalid-hex")
 	if err == nil {
 		t.Error("Should fail with invalid hex")
 	}
-	
+
 	// Test wrong size hex
 	_, err = ParseHexNamespace("0x0011")
 	if err == nil {
@@ -352,46 +275,46 @@ func TestHexStringConversion(t *testing.T) {
 
 func TestCelestiaSpecCompliance(t *testing.T) {
 	// Test that our implementation follows the Celestia namespace specification
-	
+
 	t.Run("namespace structure", func(t *testing.T) {
 		ns, err := NewNamespaceV0([]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		
+
 		nsBytes := ns.Bytes()
-		
+
 		// Check total size is 29 bytes (1 version + 28 ID)
 		if len(nsBytes) != 29 {
 			t.Errorf("Total namespace size should be 29 bytes, got %d", len(nsBytes))
 		}
-		
+
 		// Check version byte is at position 0
 		if nsBytes[0] != byte(0) {
 			t.Errorf("Version byte should be 0, got %d", nsBytes[0])
 		}
-		
+
 		// Check ID is 28 bytes starting at position 1
 		if len(nsBytes[1:]) != 28 {
 			t.Errorf("ID should be 28 bytes, got %d", len(nsBytes[1:]))
 		}
 	})
-	
+
 	t.Run("version 0 requirements", func(t *testing.T) {
 		ns, err := NewNamespaceV0([]byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		
+
 		nsBytes := ns.Bytes()
-		
+
 		// For version 0, first 18 bytes of ID must be zero
 		for i := 1; i <= 18; i++ {
 			if nsBytes[i] != byte(0) {
 				t.Errorf("Bytes 1-18 should be zero for version 0, but byte %d is %d", i, nsBytes[i])
 			}
 		}
-		
+
 		// Last 10 bytes should contain our data
 		expectedData := []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}
 		actualData := nsBytes[19:29]
@@ -399,17 +322,17 @@ func TestCelestiaSpecCompliance(t *testing.T) {
 			t.Errorf("Last 10 bytes should contain user data, expected %v, got %v", expectedData, actualData)
 		}
 	})
-	
+
 	t.Run("example from spec", func(t *testing.T) {
 		// Create a namespace similar to the example in the spec
 		ns, err := NewNamespaceV0([]byte{0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		
+
 		hexStr := ns.HexString()
 		t.Logf("Example namespace: %s", hexStr)
-		
+
 		// Verify it matches the expected format
 		if len(hexStr) != 60 {
 			t.Errorf("Hex string should be 60 chars (0x + 58 hex chars), got %d", len(hexStr))
@@ -431,37 +354,37 @@ func TestRealWorldNamespaces(t *testing.T) {
 		"test-headers",
 		"test-data",
 	}
-	
+
 	seen := make(map[string]bool)
-	
+
 	for _, nsStr := range namespaces {
 		t.Run(nsStr, func(t *testing.T) {
 			// Convert string to namespace
-			nsBytes := PrepareNamespace([]byte(nsStr))
-			
+			nsBytes := NamespaceFromString(nsStr)
+
 			// Verify it's valid
-			ns, err := NamespaceFromBytes(nsBytes)
+			ns, err := NamespaceFromBytes(nsBytes.Bytes())
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			if !ns.IsValidForVersion0() {
 				t.Error("namespace should be valid for version 0")
 			}
-			
+
 			// Verify uniqueness
-			hexStr := hex.EncodeToString(nsBytes)
+			hexStr := hex.EncodeToString(nsBytes.Bytes())
 			if seen[hexStr] {
 				t.Errorf("Namespace should be unique, but %s was already seen", hexStr)
 			}
 			seen[hexStr] = true
-			
+
 			// Verify deterministic
-			nsBytes2 := PrepareNamespace([]byte(nsStr))
-			if !bytes.Equal(nsBytes, nsBytes2) {
+			nsBytes2 := NamespaceFromString(nsStr)
+			if !bytes.Equal(nsBytes.Bytes(), nsBytes2.Bytes()) {
 				t.Error("Should be deterministic")
 			}
-			
-			t.Logf("Namespace for '%s': %s", nsStr, hex.EncodeToString(nsBytes))
+
+			t.Logf("Namespace for '%s': %s", nsStr, hex.EncodeToString(nsBytes.Bytes()))
 		})
 	}
 }

--- a/da/jsonrpc/client.go
+++ b/da/jsonrpc/client.go
@@ -40,9 +40,8 @@ type API struct {
 
 // Get returns Blob for each given ID, or an error.
 func (api *API) Get(ctx context.Context, ids []da.ID, ns []byte) ([]da.Blob, error) {
-	preparedNs := da.PrepareNamespace(ns)
-	api.Logger.Debug().Str("method", "Get").Int("num_ids", len(ids)).Str("namespace", hex.EncodeToString(preparedNs)).Msg("Making RPC call")
-	res, err := api.Internal.Get(ctx, ids, preparedNs)
+	api.Logger.Debug().Str("method", "Get").Int("num_ids", len(ids)).Str("namespace", hex.EncodeToString(ns)).Msg("Making RPC call")
+	res, err := api.Internal.Get(ctx, ids, ns)
 	if err != nil {
 		if strings.Contains(err.Error(), context.Canceled.Error()) {
 			api.Logger.Debug().Str("method", "Get").Msg("RPC call canceled due to context cancellation")
@@ -58,9 +57,8 @@ func (api *API) Get(ctx context.Context, ids []da.ID, ns []byte) ([]da.Blob, err
 
 // GetIDs returns IDs of all Blobs located in DA at given height.
 func (api *API) GetIDs(ctx context.Context, height uint64, ns []byte) (*da.GetIDsResult, error) {
-	preparedNs := da.PrepareNamespace(ns)
-	api.Logger.Debug().Str("method", "GetIDs").Uint64("height", height).Str("namespace", hex.EncodeToString(preparedNs)).Msg("Making RPC call")
-	res, err := api.Internal.GetIDs(ctx, height, preparedNs)
+	api.Logger.Debug().Str("method", "GetIDs").Uint64("height", height).Str("namespace", hex.EncodeToString(ns)).Msg("Making RPC call")
+	res, err := api.Internal.GetIDs(ctx, height, ns)
 	if err != nil {
 		// Using strings.contains since JSON RPC serialization doesn't preserve error wrapping
 		// Check if the error is specifically BlobNotFound, otherwise log and return
@@ -92,9 +90,8 @@ func (api *API) GetIDs(ctx context.Context, height uint64, ns []byte) (*da.GetID
 
 // GetProofs returns inclusion Proofs for Blobs specified by their IDs.
 func (api *API) GetProofs(ctx context.Context, ids []da.ID, ns []byte) ([]da.Proof, error) {
-	preparedNs := da.PrepareNamespace(ns)
-	api.Logger.Debug().Str("method", "GetProofs").Int("num_ids", len(ids)).Str("namespace", hex.EncodeToString(preparedNs)).Msg("Making RPC call")
-	res, err := api.Internal.GetProofs(ctx, ids, preparedNs)
+	api.Logger.Debug().Str("method", "GetProofs").Int("num_ids", len(ids)).Str("namespace", hex.EncodeToString(ns)).Msg("Making RPC call")
+	res, err := api.Internal.GetProofs(ctx, ids, ns)
 	if err != nil {
 		api.Logger.Error().Err(err).Str("method", "GetProofs").Msg("RPC call failed")
 	} else {
@@ -105,9 +102,8 @@ func (api *API) GetProofs(ctx context.Context, ids []da.ID, ns []byte) ([]da.Pro
 
 // Commit creates a Commitment for each given Blob.
 func (api *API) Commit(ctx context.Context, blobs []da.Blob, ns []byte) ([]da.Commitment, error) {
-	preparedNs := da.PrepareNamespace(ns)
-	api.Logger.Debug().Str("method", "Commit").Int("num_blobs", len(blobs)).Str("namespace", hex.EncodeToString(preparedNs)).Msg("Making RPC call")
-	res, err := api.Internal.Commit(ctx, blobs, preparedNs)
+	api.Logger.Debug().Str("method", "Commit").Int("num_blobs", len(blobs)).Str("namespace", hex.EncodeToString(ns)).Msg("Making RPC call")
+	res, err := api.Internal.Commit(ctx, blobs, ns)
 	if err != nil {
 		api.Logger.Error().Err(err).Str("method", "Commit").Msg("RPC call failed")
 	} else {
@@ -118,9 +114,8 @@ func (api *API) Commit(ctx context.Context, blobs []da.Blob, ns []byte) ([]da.Co
 
 // Validate validates Commitments against the corresponding Proofs. This should be possible without retrieving the Blobs.
 func (api *API) Validate(ctx context.Context, ids []da.ID, proofs []da.Proof, ns []byte) ([]bool, error) {
-	preparedNs := da.PrepareNamespace(ns)
-	api.Logger.Debug().Str("method", "Validate").Int("num_ids", len(ids)).Int("num_proofs", len(proofs)).Str("namespace", hex.EncodeToString(preparedNs)).Msg("Making RPC call")
-	res, err := api.Internal.Validate(ctx, ids, proofs, preparedNs)
+	api.Logger.Debug().Str("method", "Validate").Int("num_ids", len(ids)).Int("num_proofs", len(proofs)).Str("namespace", hex.EncodeToString(ns)).Msg("Making RPC call")
+	res, err := api.Internal.Validate(ctx, ids, proofs, ns)
 	if err != nil {
 		api.Logger.Error().Err(err).Str("method", "Validate").Msg("RPC call failed")
 	} else {
@@ -131,15 +126,14 @@ func (api *API) Validate(ctx context.Context, ids []da.ID, proofs []da.Proof, ns
 
 // Submit submits the Blobs to Data Availability layer.
 func (api *API) Submit(ctx context.Context, blobs []da.Blob, gasPrice float64, ns []byte) ([]da.ID, error) {
-	preparedNs := da.PrepareNamespace(ns)
-	api.Logger.Debug().Str("method", "Submit").Int("num_blobs", len(blobs)).Float64("gas_price", gasPrice).Str("namespace", hex.EncodeToString(preparedNs)).Msg("Making RPC call")
-	res, err := api.Internal.Submit(ctx, blobs, gasPrice, preparedNs)
+	api.Logger.Debug().Str("method", "Submit").Int("num_blobs", len(blobs)).Float64("gas_price", gasPrice).Str("namespace", hex.EncodeToString(ns)).Msg("Making RPC call")
+	res, err := api.Internal.Submit(ctx, blobs, gasPrice, ns)
 	if err != nil {
 		if strings.Contains(err.Error(), context.Canceled.Error()) {
 			api.Logger.Debug().Str("method", "Submit").Msg("RPC call canceled due to context cancellation")
 			return res, context.Canceled
 		}
-		api.Logger.Error().Err(err).Str("method", "Submit").Bytes("namespace", preparedNs).Msg("RPC call failed")
+		api.Logger.Error().Err(err).Str("method", "Submit").Bytes("namespace", ns).Msg("RPC call failed")
 	} else {
 		api.Logger.Debug().Str("method", "Submit").Int("num_ids_returned", len(res)).Msg("RPC call successful")
 	}
@@ -172,9 +166,8 @@ func (api *API) SubmitWithOptions(ctx context.Context, inputBlobs []da.Blob, gas
 		return nil, da.ErrBlobSizeOverLimit
 	}
 
-	preparedNs := da.PrepareNamespace(ns)
-	api.Logger.Debug().Str("method", "SubmitWithOptions").Int("num_blobs", len(inputBlobs)).Uint64("total_size", totalSize).Float64("gas_price", gasPrice).Str("namespace", hex.EncodeToString(preparedNs)).Msg("Making RPC call")
-	res, err := api.Internal.SubmitWithOptions(ctx, inputBlobs, gasPrice, preparedNs, options)
+	api.Logger.Debug().Str("method", "SubmitWithOptions").Int("num_blobs", len(inputBlobs)).Uint64("total_size", totalSize).Float64("gas_price", gasPrice).Str("namespace", hex.EncodeToString(ns)).Msg("Making RPC call")
+	res, err := api.Internal.SubmitWithOptions(ctx, inputBlobs, gasPrice, ns, options)
 	if err != nil {
 		if strings.Contains(err.Error(), context.Canceled.Error()) {
 			api.Logger.Debug().Str("method", "SubmitWithOptions").Msg("RPC call canceled due to context cancellation")

--- a/da/jsonrpc/proxy_test.go
+++ b/da/jsonrpc/proxy_test.go
@@ -231,10 +231,11 @@ func HeightFromFutureTest(t *testing.T, d coreda.DA) {
 // TestSubmitWithOptions tests the SubmitWithOptions method with various scenarios
 func TestSubmitWithOptions(t *testing.T) {
 	ctx := context.Background()
-	testNamespace := []byte("options_test")
+	testNamespace := "options_test"
 	// The client will convert the namespace string to a proper Celestia namespace
 	// using SHA256 hashing and version 0 format (1 version byte + 28 ID bytes)
-	encodedNamespace := coreda.PrepareNamespace(testNamespace)
+	namespace := coreda.NamespaceFromString(testNamespace)
+	encodedNamespace := namespace.Bytes()
 	testOptions := []byte("test_options")
 	gasPrice := 0.0
 
@@ -257,7 +258,7 @@ func TestSubmitWithOptions(t *testing.T) {
 
 		mockAPI.On("SubmitWithOptions", ctx, blobs, gasPrice, encodedNamespace, testOptions).Return(expectedIDs, nil).Once()
 
-		ids, err := client.DA.SubmitWithOptions(ctx, blobs, gasPrice, testNamespace, testOptions)
+		ids, err := client.DA.SubmitWithOptions(ctx, blobs, gasPrice, encodedNamespace, testOptions)
 
 		require.NoError(t, err)
 		assert.Equal(t, expectedIDs, ids)
@@ -271,7 +272,7 @@ func TestSubmitWithOptions(t *testing.T) {
 		largerBlob := make([]byte, testMaxBlobSize+1)
 		blobs := []coreda.Blob{largerBlob, []byte("this blob is definitely too large")}
 
-		_, err := client.DA.SubmitWithOptions(ctx, blobs, gasPrice, testNamespace, testOptions)
+		_, err := client.DA.SubmitWithOptions(ctx, blobs, gasPrice, encodedNamespace, testOptions)
 
 		require.Error(t, err)
 		mockAPI.AssertExpectations(t)
@@ -286,7 +287,7 @@ func TestSubmitWithOptions(t *testing.T) {
 
 		blobs := []coreda.Blob{blobsizes, blobsizes, blobsizesOver}
 
-		ids, err := client.DA.SubmitWithOptions(ctx, blobs, gasPrice, testNamespace, testOptions)
+		ids, err := client.DA.SubmitWithOptions(ctx, blobs, gasPrice, encodedNamespace, testOptions)
 
 		require.Error(t, err)
 		assert.ErrorIs(t, err, coreda.ErrBlobSizeOverLimit)
@@ -304,7 +305,7 @@ func TestSubmitWithOptions(t *testing.T) {
 		largerBlob := make([]byte, testMaxBlobSize+1)
 		blobs := []coreda.Blob{largerBlob, []byte("small")}
 
-		ids, err := client.DA.SubmitWithOptions(ctx, blobs, gasPrice, testNamespace, testOptions)
+		ids, err := client.DA.SubmitWithOptions(ctx, blobs, gasPrice, encodedNamespace, testOptions)
 
 		require.Error(t, err)
 		assert.ErrorIs(t, err, coreda.ErrBlobSizeOverLimit)
@@ -320,7 +321,7 @@ func TestSubmitWithOptions(t *testing.T) {
 
 		var blobs []coreda.Blob
 
-		ids, err := client.DA.SubmitWithOptions(ctx, blobs, gasPrice, testNamespace, testOptions)
+		ids, err := client.DA.SubmitWithOptions(ctx, blobs, gasPrice, encodedNamespace, testOptions)
 
 		require.NoError(t, err)
 		assert.Empty(t, ids)
@@ -338,7 +339,7 @@ func TestSubmitWithOptions(t *testing.T) {
 
 		mockAPI.On("SubmitWithOptions", ctx, blobs, gasPrice, encodedNamespace, testOptions).Return(nil, expectedError).Once()
 
-		ids, err := client.DA.SubmitWithOptions(ctx, blobs, gasPrice, testNamespace, testOptions)
+		ids, err := client.DA.SubmitWithOptions(ctx, blobs, gasPrice, encodedNamespace, testOptions)
 
 		require.Error(t, err)
 		assert.ErrorIs(t, err, expectedError)

--- a/node/helpers_test.go
+++ b/node/helpers_test.go
@@ -36,7 +36,7 @@ const (
 	MockDAAddress = "grpc://localhost:7990"
 
 	// MockDANamespace is a sample namespace used by the mock DA client
-	MockDANamespace = "00000000000000000000000000000000000000000000000000deadbeef"
+	MockDANamespace = "mock-namespace"
 
 	// MockExecutorAddress is a sample address used by the mock executor
 	MockExecutorAddress = "127.0.0.1:40041"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -259,8 +259,8 @@ func validateNamespace(namespace string) error {
 		return fmt.Errorf("namespace cannot be empty")
 	}
 
-	namespaceBz := da.PrepareNamespace([]byte(namespace))
-	if _, err := share.NewNamespaceFromBytes(namespaceBz); err != nil {
+	ns := da.NamespaceFromString(namespace)
+	if _, err := share.NewNamespaceFromBytes(ns.Bytes()); err != nil {
 		return fmt.Errorf("could not validate namespace (%s): %w", namespace, err)
 	}
 	return nil

--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"encoding/binary"
-	"encoding/hex"
 	"errors"
 
 	"connectrpc.com/connect"
@@ -208,12 +207,12 @@ func (cs *ConfigServer) GetNamespace(
 	req *connect.Request[emptypb.Empty],
 ) (*connect.Response[pb.GetNamespaceResponse], error) {
 
-	hns := coreda.PrepareNamespace([]byte(cs.config.DA.GetNamespace()))
-	dns := coreda.PrepareNamespace([]byte(cs.config.DA.GetDataNamespace()))
+	hns := coreda.NamespaceFromString(cs.config.DA.GetNamespace())
+	dns := coreda.NamespaceFromString(cs.config.DA.GetDataNamespace())
 
 	return connect.NewResponse(&pb.GetNamespaceResponse{
-		HeaderNamespace: hex.EncodeToString(hns),
-		DataNamespace:   hex.EncodeToString(dns),
+		HeaderNamespace: hns.HexString(),
+		DataNamespace:   dns.HexString(),
 	}), nil
 }
 

--- a/types/da.go
+++ b/types/da.go
@@ -22,11 +22,10 @@ func SubmitWithHelpers(
 	logger zerolog.Logger,
 	data [][]byte,
 	gasPrice float64,
-	namespace string,
+	namespace []byte,
 	options []byte,
 ) coreda.ResultSubmit { // Return core ResultSubmit type
-	ns := coreda.NamespaceFromString(namespace)
-	ids, err := da.SubmitWithOptions(ctx, data, gasPrice, ns.Bytes(), options)
+	ids, err := da.SubmitWithOptions(ctx, data, gasPrice, namespace, options)
 
 	// Handle errors returned by Submit
 	if err != nil {
@@ -112,11 +111,10 @@ func RetrieveWithHelpers(
 	da coreda.DA,
 	logger zerolog.Logger,
 	dataLayerHeight uint64,
-	namespace string,
+	namespace []byte,
 ) coreda.ResultRetrieve {
-	namespaceBz := coreda.NamespaceFromString(namespace).Bytes()
 	// 1. Get IDs
-	idsResult, err := da.GetIDs(ctx, dataLayerHeight, namespaceBz)
+	idsResult, err := da.GetIDs(ctx, dataLayerHeight, namespace)
 	if err != nil {
 		// Handle specific "not found" error
 		if strings.Contains(err.Error(), coreda.ErrBlobNotFound.Error()) {
@@ -171,7 +169,7 @@ func RetrieveWithHelpers(
 	for i := 0; i < len(idsResult.IDs); i += batchSize {
 		end := min(i+batchSize, len(idsResult.IDs))
 
-		batchBlobs, err := da.Get(ctx, idsResult.IDs[i:end], namespaceBz)
+		batchBlobs, err := da.Get(ctx, idsResult.IDs[i:end], namespace)
 		if err != nil {
 			// Handle errors during Get
 			logger.Error().Uint64("height", dataLayerHeight).Int("num_ids", len(idsResult.IDs)).Err(err).Msg("Retrieve helper: Failed to get blobs")

--- a/types/da.go
+++ b/types/da.go
@@ -112,11 +112,11 @@ func RetrieveWithHelpers(
 	da coreda.DA,
 	logger zerolog.Logger,
 	dataLayerHeight uint64,
-	namespace []byte,
+	namespace string,
 ) coreda.ResultRetrieve {
-
+	namespaceBz := coreda.NamespaceFromString(namespace).Bytes()
 	// 1. Get IDs
-	idsResult, err := da.GetIDs(ctx, dataLayerHeight, namespace)
+	idsResult, err := da.GetIDs(ctx, dataLayerHeight, namespaceBz)
 	if err != nil {
 		// Handle specific "not found" error
 		if strings.Contains(err.Error(), coreda.ErrBlobNotFound.Error()) {
@@ -171,7 +171,7 @@ func RetrieveWithHelpers(
 	for i := 0; i < len(idsResult.IDs); i += batchSize {
 		end := min(i+batchSize, len(idsResult.IDs))
 
-		batchBlobs, err := da.Get(ctx, idsResult.IDs[i:end], namespace)
+		batchBlobs, err := da.Get(ctx, idsResult.IDs[i:end], namespaceBz)
 		if err != nil {
 			// Handle errors during Get
 			logger.Error().Uint64("height", dataLayerHeight).Int("num_ids", len(idsResult.IDs)).Err(err).Msg("Retrieve helper: Failed to get blobs")

--- a/types/da.go
+++ b/types/da.go
@@ -22,10 +22,11 @@ func SubmitWithHelpers(
 	logger zerolog.Logger,
 	data [][]byte,
 	gasPrice float64,
-	namespace []byte, // New namespace parameter
+	namespace string,
 	options []byte,
 ) coreda.ResultSubmit { // Return core ResultSubmit type
-	ids, err := da.SubmitWithOptions(ctx, data, gasPrice, namespace, options)
+	ns := coreda.NamespaceFromString(namespace)
+	ids, err := da.SubmitWithOptions(ctx, data, gasPrice, ns.Bytes(), options)
 
 	// Handle errors returned by Submit
 	if err != nil {

--- a/types/da_test.go
+++ b/types/da_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/evstack/ev-node/core/da"
 	coreda "github.com/evstack/ev-node/core/da"
 	"github.com/evstack/ev-node/test/mocks"
 	"github.com/evstack/ev-node/types"
@@ -117,8 +118,10 @@ func TestSubmitWithHelpers(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockDA := mocks.NewMockDA(t)
-			namespace := []byte("test-namespace")
-			mockDA.On("SubmitWithOptions", mock.Anything, tc.data, tc.gasPrice, namespace, tc.options).Return(tc.submitIDs, tc.submitErr)
+			namespace := "test-namespace"
+			encodedNamespace := da.NamespaceFromString(namespace)
+
+			mockDA.On("SubmitWithOptions", mock.Anything, tc.data, tc.gasPrice, encodedNamespace.Bytes(), tc.options).Return(tc.submitIDs, tc.submitErr)
 
 			result := types.SubmitWithHelpers(context.Background(), mockDA, logger, tc.data, tc.gasPrice, namespace, tc.options)
 

--- a/types/da_test.go
+++ b/types/da_test.go
@@ -117,12 +117,11 @@ func TestSubmitWithHelpers(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockDA := mocks.NewMockDA(t)
-			namespace := "test-namespace"
-			encodedNamespace := coreda.NamespaceFromString(namespace)
+			encodedNamespace := coreda.NamespaceFromString("test-namespace")
 
 			mockDA.On("SubmitWithOptions", mock.Anything, tc.data, tc.gasPrice, encodedNamespace.Bytes(), tc.options).Return(tc.submitIDs, tc.submitErr)
 
-			result := types.SubmitWithHelpers(context.Background(), mockDA, logger, tc.data, tc.gasPrice, namespace, tc.options)
+			result := types.SubmitWithHelpers(context.Background(), mockDA, logger, tc.data, tc.gasPrice, encodedNamespace.Bytes(), tc.options)
 
 			assert.Equal(t, tc.expectedCode, result.Code)
 			if tc.expectedErrMsg != "" {
@@ -222,6 +221,7 @@ func TestRetrieveWithHelpers(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockDA := mocks.NewMockDA(t)
+			encodedNamespace := coreda.NamespaceFromString("test-namespace")
 
 			mockDA.On("GetIDs", mock.Anything, dataLayerHeight, mock.Anything).Return(tc.getIDsResult, tc.getIDsErr)
 
@@ -229,7 +229,7 @@ func TestRetrieveWithHelpers(t *testing.T) {
 				mockDA.On("Get", mock.Anything, tc.getIDsResult.IDs, mock.Anything).Return(mockBlobs, tc.getBlobsErr)
 			}
 
-			result := types.RetrieveWithHelpers(context.Background(), mockDA, logger, dataLayerHeight, "test-namespace")
+			result := types.RetrieveWithHelpers(context.Background(), mockDA, logger, dataLayerHeight, encodedNamespace.Bytes())
 
 			assert.Equal(t, tc.expectedCode, result.Code)
 			assert.Equal(t, tc.expectedHeight, result.Height)

--- a/types/da_test.go
+++ b/types/da_test.go
@@ -229,7 +229,7 @@ func TestRetrieveWithHelpers(t *testing.T) {
 				mockDA.On("Get", mock.Anything, tc.getIDsResult.IDs, mock.Anything).Return(mockBlobs, tc.getBlobsErr)
 			}
 
-			result := types.RetrieveWithHelpers(context.Background(), mockDA, logger, dataLayerHeight, []byte("test-namespace"))
+			result := types.RetrieveWithHelpers(context.Background(), mockDA, logger, dataLayerHeight, "test-namespace")
 
 			assert.Equal(t, tc.expectedCode, result.Code)
 			assert.Equal(t, tc.expectedHeight, result.Height)

--- a/types/da_test.go
+++ b/types/da_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/evstack/ev-node/core/da"
 	coreda "github.com/evstack/ev-node/core/da"
 	"github.com/evstack/ev-node/test/mocks"
 	"github.com/evstack/ev-node/types"
@@ -119,7 +118,7 @@ func TestSubmitWithHelpers(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mockDA := mocks.NewMockDA(t)
 			namespace := "test-namespace"
-			encodedNamespace := da.NamespaceFromString(namespace)
+			encodedNamespace := coreda.NamespaceFromString(namespace)
 
 			mockDA.On("SubmitWithOptions", mock.Anything, tc.data, tc.gasPrice, encodedNamespace.Bytes(), tc.options).Return(tc.submitIDs, tc.submitErr)
 


### PR DESCRIPTION
Remove `PrepareNamespace`.
The caller must know what the namespace is: s it bytes? Or is it a string.
If we are using `PrepareNamespace`, we are losing this information, so strings of 29 characters will trigger the wrong path and do not pass validation.