### PR TITLE
refactor: use the built-in max to simplify the code

### DIFF
--- a/block/internal/syncing/syncer.go
+++ b/block/internal/syncing/syncer.go
@@ -196,10 +196,7 @@ func (s *Syncer) initializeState() error {
 	s.SetLastState(state)
 
 	// Set DA height
-	daHeight := state.DAHeight
-	if daHeight < s.config.DA.StartHeight {
-		daHeight = s.config.DA.StartHeight
-	}
+	daHeight := max(state.DAHeight, s.config.DA.StartHeight)
 	s.SetDAHeight(daHeight)
 
 	s.logger.Info().
@@ -342,10 +339,7 @@ func (s *Syncer) syncLoop() {
 			}
 		default:
 			// Prevent busy-waiting when no events are available.
-			waitTime := 10 * time.Millisecond
-			if waitTime > s.config.Node.BlockTime.Duration {
-				waitTime = s.config.Node.BlockTime.Duration
-			}
+			waitTime := min(10*time.Millisecond, s.config.Node.BlockTime.Duration)
 
 			time.Sleep(waitTime)
 		}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.

