### PR TITLE
chore: Go toolchain alignment

### DIFF
--- a/core/go.mod
+++ b/core/go.mod
@@ -1,5 +1,5 @@
 module github.com/evstack/ev-node/core
 
-go 1.24.1
+go 1.24.6
 
 // Please keep this pkg a 0 dependency pkg.

--- a/da/go.mod
+++ b/da/go.mod
@@ -1,6 +1,6 @@
 module github.com/evstack/ev-node/da
 
-go 1.24.1
+go 1.24.6
 
 require (
 	github.com/evstack/ev-node/core v1.0.0-beta.3

--- a/execution/grpc/go.mod
+++ b/execution/grpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/evstack/ev-node/execution/grpc
 
-go 1.24.2
+go 1.24.6
 
 require (
 	connectrpc.com/connect v1.18.1

--- a/sequencers/single/go.mod
+++ b/sequencers/single/go.mod
@@ -1,6 +1,6 @@
 module github.com/evstack/ev-node/sequencers/single
 
-go 1.24.2
+go 1.24.6
 
 require (
 	github.com/evstack/ev-node v1.0.0-beta.4


### PR DESCRIPTION
## Description

Unify the `go` directive to 1.24.6 across submodules (`core`, `da`, `execution/grpc`, `sequencers/single`) to match the root `go.mod`.