### PR TITLE
fix: fix block sync p2p for follower nodes

### DIFF
--- a/block/internal/syncing/syncer.go
+++ b/block/internal/syncing/syncer.go
@@ -453,13 +453,6 @@ func (s *Syncer) trySyncNextBlock(event *common.DAHeightEvent) error {
 		return fmt.Errorf("failed to update height: %w", err)
 	}
 
-	// initialize p2p sync stores if this is genesis height and stores are empty
-	if header.Height() == s.genesis.InitialHeight {
-		if err := s.ensureSyncStoresInitialized(header, data); err != nil {
-			s.logger.Warn().Err(err).Msg("failed to initialize p2p sync stores")
-		}
-	}
-
 	// Update state
 	if event.DaHeight > newState.DAHeight {
 		newState.DAHeight = event.DaHeight
@@ -617,35 +610,4 @@ func (s *Syncer) processPendingEvents() {
 
 		nextHeight++
 	}
-}
-
-// ensureSyncStoresInitialized initializes the p2p sync stores with genesis blocks if they are empty.
-// this is needed for follower nodes that start with no p2p blocks available and receive their first
-// block from DA. without this, the p2p sync stores remain empty and p2p block sync never works.
-func (s *Syncer) ensureSyncStoresInitialized(header *types.SignedHeader, data *types.Data) error {
-	if s.headerStore == nil || s.dataStore == nil {
-		return nil
-	}
-
-	// check if header store is empty
-	_, err := s.headerStore.Head(s.ctx)
-	if err == nil {
-		// store already initialized
-		return nil
-	}
-
-	s.logger.Info().Uint64("height", header.Height()).Msg("initializing p2p sync stores with genesis block")
-
-	// append genesis header to header store
-	if err := s.headerStore.Append(s.ctx, header); err != nil {
-		return fmt.Errorf("failed to append genesis header to store: %w", err)
-	}
-
-	// append genesis data to data store
-	if err := s.dataStore.Append(s.ctx, data); err != nil {
-		return fmt.Errorf("failed to append genesis data to store: %w", err)
-	}
-
-	s.logger.Info().Msg("p2p sync stores initialized successfully")
-	return nil
 }

--- a/pkg/sync/sync_service.go
+++ b/pkg/sync/sync_service.go
@@ -253,7 +253,6 @@ func (syncService *SyncService[H]) setupP2PInfrastructure(ctx context.Context) (
 		return nil, err
 	}
 
-	// Start the store
 	if err := syncService.store.Start(ctx); err != nil {
 		return nil, fmt.Errorf("error while starting store: %w", err)
 	}
@@ -264,7 +263,6 @@ func (syncService *SyncService[H]) setupP2PInfrastructure(ctx context.Context) (
 	}
 	networkID := syncService.getNetworkID(network)
 
-	// Start P2P server (Exchange server for serving headers/data to peers)
 	if syncService.p2pServer, err = newP2PServer(syncService.p2p.Host(), syncService.store, networkID); err != nil {
 		return nil, fmt.Errorf("error while creating p2p server: %w", err)
 	}
@@ -274,14 +272,12 @@ func (syncService *SyncService[H]) setupP2PInfrastructure(ctx context.Context) (
 
 	peerIDs := syncService.getPeerIDs()
 
-	// Start Exchange client (for fetching headers/data from peers)
 	if syncService.ex, err = newP2PExchange[H](syncService.p2p.Host(), peerIDs, networkID, syncService.genesis.ChainID, syncService.p2p.ConnectionGater()); err != nil {
 		return nil, fmt.Errorf("error while creating exchange: %w", err)
 	}
 	if err := syncService.ex.Start(ctx); err != nil {
 		return nil, fmt.Errorf("error while starting exchange: %w", err)
 	}
-
 	return peerIDs, nil
 }
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

There was an issue with the block sync p2p where follower nodes were falling back on DA sync and never catching up to the aggregator.

The root cause was that the sync service had started subscribing **before** the service was initialized in `initFromP2PWithRetry`. 

This PR separates out the construction of the components with when the service is started so that it happens after initialization has happened.

Here is a snippet of code from the p2p test using a commit with this fix

```
    testsuite_test.go:215: Waiting for first follower to sync...
    testsuite_test.go:347: Follower 1: height=23, aggregator=24, delta=1
    testsuite_test.go:355: All 1 follower nodes are now in sync (within 5 blocks of aggregator)
    testsuite_test.go:64: Evolve chain started
    liveness_test.go:57: Testing block production...
    liveness_test.go:61: Testing transaction submission and query...
    logger.go:146: 2025-10-02T13:39:26.869+0100	INFO	Exec	{"validator": true, "i": 0, "chain_id": "evolve-test", "test": "TestDockerIntegrationTestSuite/TestLivenessWithCelestiaDA", "image": "evolve-gm:latest", "test_name": "TestDockerIntegrationTestSuite/TestLivenessWithCelestiaDA", "command": "gmd keys add bob-gewnuv --coin-type 118 --keyring-backend test --home /var/cosmos-chain/evolve", "env,": [], "hostname": "TestDockerIntegrationTestSuite_._tLivenessWithCelestiaDA-sbyipj", "container": "TestDockerIntegrationTestSuite_TestLivenessWithCelestiaDA-sbyipj"}
    logger.go:146: 2025-10-02T13:39:27.261+0100	INFO	Exec	{"validator": true, "i": 0, "chain_id": "evolve-test", "test": "TestDockerIntegrationTestSuite/TestLivenessWithCelestiaDA", "image": "evolve-gm:latest", "test_name": "TestDockerIntegrationTestSuite/TestLivenessWithCelestiaDA", "command": "gmd keys show --address bob-gewnuv --home /var/cosmos-chain/evolve --keyring-backend test", "env,": [], "hostname": "TestDockerIntegrationTestSuite_._tLivenessWithCelestiaDA-awrotn", "container": "TestDockerIntegrationTestSuite_TestLivenessWithCelestiaDA-awrotn"}
    logger.go:146: 2025-10-02T13:39:32.715+0100	INFO	broadcasted message	{"wallet_address": "gm120wyqka8x8a6l2r72wdyjmhcn7w7740e963cpm", "message_types": ["MsgSend"], "tx_hash": "CE14E712CEB4C9D9382094146BA3C02C08F9273603767F0EF0FDB067E189C567"}
    logger.go:146: 2025-10-02T13:39:37.786+0100	INFO	Exec	{"validator": true, "i": 0, "chain_id": "evolve-test", "test": "TestDockerIntegrationTestSuite/TestLivenessWithCelestiaDA", "image": "evolve-gm:latest", "test_name": "TestDockerIntegrationTestSuite/TestLivenessWithCelestiaDA", "command": "gmd keys add carol --coin-type 118 --keyring-backend test --home /var/cosmos-chain/evolve", "env,": [], "hostname": "TestDockerIntegrationTestSuite_._tLivenessWithCelestiaDA-cerorr", "container": "TestDockerIntegrationTestSuite_TestLivenessWithCelestiaDA-cerorr"}
    logger.go:146: 2025-10-02T13:39:38.198+0100	INFO	Exec	{"validator": true, "i": 0, "chain_id": "evolve-test", "test": "TestDockerIntegrationTestSuite/TestLivenessWithCelestiaDA", "image": "evolve-gm:latest", "test_name": "TestDockerIntegrationTestSuite/TestLivenessWithCelestiaDA", "command": "gmd keys show --address carol --home /var/cosmos-chain/evolve --keyring-backend test", "env,": [], "hostname": "TestDockerIntegrationTestSuite_._tLivenessWithCelestiaDA-rhipbd", "container": "TestDockerIntegrationTestSuite_TestLivenessWithCelestiaDA-rhipbd"}
    liveness_test.go:78: Querying Bob's initial balance...
    liveness_test.go:85: Sending 100stake from Bob to Carol...
    logger.go:146: 2025-10-02T13:39:43.624+0100	INFO	broadcasted message	{"wallet_address": "gm1lve80wgtljp3rcqlfn8s8dv2wz8z6k9jttv3dd", "message_types": ["MsgSend"], "tx_hash": "0C76963C168E1BF24388CC1ACDBDD649978DFC3CE4E56F9102A6235AB31D8653"}
    liveness_test.go:64: Test completed successfully
    setup.go:188: Pruned 4 volumes, reclaiming approximately 103.3 MB
    setup.go:223: Pruned unused networks: [tastora-jvkkbvke]
--- PASS: TestDockerIntegrationTestSuite (101.28s)
    --- PASS: TestDockerIntegrationTestSuite/TestLivenessWithCelestiaDA (101.28s)
PASS
ok  	github.com/evstack/ev-abci/tests/integration	101.849s
```

Previously the delta was always staying at ~10-15 and the nodes would never catch up. With this change we get

`testsuite_test.go:347: Follower 1: height=23, aggregator=24, delta=1`

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->
