### PR TITLE
fix(types): add timeout per request in retrieve helper

### DIFF
--- a/block/internal/syncing/da_retriever.go
+++ b/block/internal/syncing/da_retriever.go
@@ -19,7 +19,9 @@ import (
 	pb "github.com/evstack/ev-node/types/pb/evnode/v1"
 )
 
-const dAFetcherTimeout = 10 * time.Second
+// dAFetcherTimeout is the timeout for fetching data from the DA
+// it needs to be high enough in case of network issues, slow DA or many blobs to download during retrieval
+const dAFetcherTimeout = 10 * time.Minute
 
 // DARetriever handles DA retrieval operations for syncing
 type DARetriever struct {


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

Downloading many blobs would timeout after 10s. We should timeout per request and for all requests.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->
