### PR TITLE
refactor(pkg/config)!: move da start height to genesis

### DIFF
--- a/apps/evm/single/README.md
+++ b/apps/evm/single/README.md
@@ -15,26 +15,28 @@ This directory contains the implementation of a single EVM sequencer using Ev-no
 
 2. Build the sequencer:
 
-    ```bash
-    go build -o evm-single .
-    ```
+   ```bash
+   go build -o evm-single .
+   ```
 
 3. Initialize the sequencer:
 
-    ```bash
-    ./evm-single init --rollkit.node.aggregator=true --rollkit.signer.passphrase secret
-    ```
+   ```bash
+   ./evm-single init --rollkit.node.aggregator=true --rollkit.signer.passphrase secret
+   ```
 
 4. Start the sequencer:
 
-    ```bash
-    ./evm-single start \
-      --evm.jwt-secret $(cat <path_to>/execution/evm/docker/jwttoken/jwt.hex) \
-      --evm.genesis-hash 0x2b8bbb1ea1e04f9c9809b4b278a8687806edc061a356c7dbc491930d8e922503 \
-      --rollkit.node.block_time 1s \
-      --rollkit.node.aggregator=true \
-      --rollkit.signer.passphrase secret
-    ```
+   ```bash
+   ./evm-single start \
+     --evm.jwt-secret $(cat <path_to>/execution/evm/docker/jwttoken/jwt.hex) \
+     --evm.genesis-hash 0x2b8bbb1ea1e04f9c9809b4b278a8687806edc061a356c7dbc491930d8e922503 \
+     --rollkit.node.block_time 1s \
+     --rollkit.node.aggregator=true \
+     --rollkit.signer.passphrase secret
+   ```
+
+Share your `genesis.json` with other node operators. Add `da_start_height` field corresponding to the first DA included block of the chain (can be queried on the sequencer node).
 
 Note: Replace `<path_to>` with the actual path to the rollkit repository. If you'd ever like to restart a fresh node, make sure to remove the originally created sequencer node directory using:
 
@@ -58,41 +60,43 @@ The sequencer can be configured using various command-line flags. The most impor
 
 2. Initialize the full node:
 
-    ```bash
-    ./evm-single init --home ~/.evm-single-full-node
-    ```
+   ```bash
+   ./evm-single init --home ~/.evm-single-full-node
+   ```
 
 3. Copy the genesis file from the sequencer node:
 
-    ```bash
-    cp ~/.evm-single/config/genesis.json ~/.evm-single-full-node/config/genesis.json
-    ```
+   ```bash
+   cp ~/.evm-single/config/genesis.json ~/.evm-single-full-node/config/genesis.json
+   ```
+
+   Verify the `da_start_height` value in the genesis file is set. If not, ask the chain developer to share it.
 
 4. Identify the sequencer node's P2P address from its logs. It will look similar to:
 
-    ```sh
-    1:55PM INF listening on address=/ip4/127.0.0.1/tcp/7676/p2p/12D3KooWJ1J5W7vpHuyktcvc71iuduRgb9pguY9wKMNVVPwweWPk module=main
-    ```
+   ```sh
+   1:55PM INF listening on address=/ip4/127.0.0.1/tcp/7676/p2p/12D3KooWJ1J5W7vpHuyktcvc71iuduRgb9pguY9wKMNVVPwweWPk module=main
+   ```
 
-    Create an environment variable with the P2P address:
+   Create an environment variable with the P2P address:
 
-    ```bash
-    export P2P_ID="12D3KooWJbD9TQoMSSSUyfhHMmgVY3LqCjxYFz8wQ92Qa6DAqtmh"
-    ```
+   ```bash
+   export P2P_ID="12D3KooWJbD9TQoMSSSUyfhHMmgVY3LqCjxYFz8wQ92Qa6DAqtmh"
+   ```
 
 5. Start the full node:
 
-    ```bash
-    ./evm-single start \
-       --home ~/.evm-single-full-node \
-       --evm.jwt-secret $(cat <path_to>/execution/evm/docker/jwttoken/jwt.hex) \
-       --evm.genesis-hash 0x2b8bbb1ea1e04f9c9809b4b278a8687806edc061a356c7dbc491930d8e922503 \
-       --rollkit.rpc.address=127.0.0.1:46657 \
-       --rollkit.p2p.listen_address=/ip4/127.0.0.1/tcp/7677 \
-       --rollkit.p2p.peers=/ip4/127.0.0.1/tcp/7676/p2p/$P2P_ID \
-       --evm.engine-url http://localhost:8561 \
-       --evm.eth-url http://localhost:8555
-    ```
+   ```bash
+   ./evm-single start \
+      --home ~/.evm-single-full-node \
+      --evm.jwt-secret $(cat <path_to>/execution/evm/docker/jwttoken/jwt.hex) \
+      --evm.genesis-hash 0x2b8bbb1ea1e04f9c9809b4b278a8687806edc061a356c7dbc491930d8e922503 \
+      --rollkit.rpc.address=127.0.0.1:46657 \
+      --rollkit.p2p.listen_address=/ip4/127.0.0.1/tcp/7677 \
+      --rollkit.p2p.peers=/ip4/127.0.0.1/tcp/7676/p2p/$P2P_ID \
+      --evm.engine-url http://localhost:8561 \
+      --evm.eth-url http://localhost:8555
+   ```
 
 If you'd ever like to restart a fresh node, make sure to remove the originally created full node directory using:
 

--- a/apps/evm/single/cmd/run.go
+++ b/apps/evm/single/cmd/run.go
@@ -67,6 +67,10 @@ var RunCmd = &cobra.Command{
 			return fmt.Errorf("failed to load genesis: %w", err)
 		}
 
+		if genesis.DAStartHeight == 0 && !nodeConfig.Node.Aggregator {
+			logger.Warn().Msg("da_start_height is not set in genesis.json, ask your chain developer")
+		}
+
 		singleMetrics, err := single.DefaultMetricsProvider(nodeConfig.Instrumentation.IsPrometheusEnabled())(genesis.ChainID)
 		if err != nil {
 			return err

--- a/apps/grpc/single/cmd/run.go
+++ b/apps/grpc/single/cmd/run.go
@@ -69,6 +69,10 @@ The execution client must implement the Evolve execution gRPC interface.`,
 			return err
 		}
 
+		if genesis.DAStartHeight == 0 && !nodeConfig.Node.Aggregator {
+			logger.Warn().Msg("da_start_height is not set in genesis.json, ask your chain developer")
+		}
+
 		// Create metrics provider
 		singleMetrics, err := single.DefaultMetricsProvider(nodeConfig.Instrumentation.IsPrometheusEnabled())(genesis.ChainID)
 		if err != nil {

--- a/apps/testapp/cmd/run.go
+++ b/apps/testapp/cmd/run.go
@@ -88,6 +88,10 @@ var RunCmd = &cobra.Command{
 			return fmt.Errorf("failed to load genesis: %w", err)
 		}
 
+		if genesis.DAStartHeight == 0 && !nodeConfig.Node.Aggregator {
+			logger.Warn().Msg("da_start_height is not set in genesis.json, ask your chain developer")
+		}
+
 		sequencer, err := single.NewSequencer(
 			ctx,
 			logger,

--- a/block/internal/syncing/syncer.go
+++ b/block/internal/syncing/syncer.go
@@ -190,7 +190,7 @@ func (s *Syncer) initializeState() error {
 	s.SetLastState(state)
 
 	// Set DA height
-	daHeight := max(state.DAHeight, s.config.DA.StartHeight)
+	daHeight := max(state.DAHeight, s.genesis.DAStartHeight)
 	s.SetDAHeight(daHeight)
 
 	s.logger.Info().

--- a/block/internal/syncing/syncer_backoff_test.go
+++ b/block/internal/syncing/syncer_backoff_test.go
@@ -318,13 +318,13 @@ func setupTestSyncer(t *testing.T, daBlockTime time.Duration) *Syncer {
 
 	cfg := config.DefaultConfig()
 	cfg.DA.BlockTime.Duration = daBlockTime
-	cfg.DA.StartHeight = 100
 
 	gen := genesis.Genesis{
 		ChainID:         "test-chain",
 		InitialHeight:   1,
 		StartTime:       time.Now().Add(-time.Hour), // Start in past
 		ProposerAddress: addr,
+		DAStartHeight:   100,
 	}
 
 	syncer := NewSyncer(

--- a/block/internal/syncing/syncer_benchmark_test.go
+++ b/block/internal/syncing/syncer_benchmark_test.go
@@ -87,8 +87,7 @@ func newBenchFixture(b *testing.B, totalHeights uint64, shuffledTx bool, daDelay
 	cfg := config.DefaultConfig()
 	// keep P2P ticker dormant unless we manually inject P2P events
 	cfg.Node.BlockTime = config.DurationWrapper{Duration: 1}
-	cfg.DA.StartHeight = daHeightOffset
-	gen := genesis.Genesis{ChainID: "bchain", InitialHeight: 1, StartTime: time.Now().Add(-time.Second), ProposerAddress: addr}
+	gen := genesis.Genesis{ChainID: "bchain", InitialHeight: 1, StartTime: time.Now().Add(-time.Second), ProposerAddress: addr, DAStartHeight: daHeightOffset}
 
 	mockExec := testmocks.NewMockExecutor(b)
 	// if execDelay > 0, sleep on ExecuteTxs to simulate slow consumer

--- a/block/internal/syncing/syncer_test.go
+++ b/block/internal/syncing/syncer_test.go
@@ -320,8 +320,7 @@ func TestSyncLoopPersistState(t *testing.T) {
 
 	addr, pub, signer := buildSyncTestSigner(t)
 	cfg := config.DefaultConfig()
-	cfg.DA.StartHeight = myDAHeightOffset
-	gen := genesis.Genesis{ChainID: "tchain", InitialHeight: 1, StartTime: time.Now().Add(-time.Second), ProposerAddress: addr}
+	gen := genesis.Genesis{ChainID: "tchain", InitialHeight: 1, StartTime: time.Now().Add(-time.Second), ProposerAddress: addr, DAStartHeight: myDAHeightOffset}
 
 	dummyExec := execution.NewDummyExecutor()
 

--- a/docs/guides/create-genesis.md
+++ b/docs/guides/create-genesis.md
@@ -116,6 +116,15 @@ For example, start the simple ignite chain with the following command:
 gmd start --evnode.node.aggregator
 ```
 
+## Share the genesis file
+
+Once the sequencer is running, share the genesis file with your peers. You can find the genesis file at `~/.${CHAIN_ID}/config/genesis.json`.
+Before doing so, add a `da_start_height` field to the genesis file, that corresponds to the height at which the first height was included on the DA layer. This height can be fetched directly from the [sequencer RPC](https://github.com/evstack/ev-node/blob/v1.0.0-beta.5/proto/evnode/v1/state_rpc.proto).
+
+```sh
+jq '.da_start_height = 1' ~/.$CHAIN_ID/config/genesis.json > temp.json && mv temp.json ~/.$CHAIN_ID/config/genesis.json
+```
+
 ## Summary
 
 By following these steps, you will set up the genesis for your chain, initialize the validator, add a genesis account, and start the chain. This guide provides a basic framework for configuring and starting your chain using the gm-world binary. Make sure you initialized your chain correctly, and use the `gmd` command for all operations.

--- a/docs/guides/da/celestia-da.md
+++ b/docs/guides/da/celestia-da.md
@@ -135,7 +135,6 @@ gmd start \
     --evnode.da.auth_token $AUTH_TOKEN \
     --evnode.da.header_namespace $DA_NAMESPACE \
     --evnode.da.data_namespace $DA_NAMESPACE \
-    --evnode.da.start_height $DA_BLOCK_HEIGHT \
     --evnode.da.address $DA_ADDRESS
 ```
 

--- a/docs/learn/config.md
+++ b/docs/learn/config.md
@@ -453,24 +453,6 @@ _Example:_ `--rollkit.da.block_time 12s`
 _Default:_ `"6s"`
 _Constant:_ `FlagDABlockTime`
 
-### DA Start Height
-
-**Description:**
-The block height on the DA layer from which Evolve should begin syncing. This is useful when deploying a new chain on an existing DA chain, allowing it to ignore historical data before its inception.
-
-**YAML:**
-
-```yaml
-da:
-  start_height: 100000
-```
-
-**Command-line Flag:**
-`--rollkit.da.start_height <uint64>`
-_Example:_ `--rollkit.da.start_height 500000`
-_Default:_ `0` (sync from the beginning)
-_Constant:_ `FlagDAStartHeight`
-
 ### DA Mempool TTL
 
 **Description:**

--- a/pkg/cmd/run_node_test.go
+++ b/pkg/cmd/run_node_test.go
@@ -67,7 +67,6 @@ func TestParseFlags(t *testing.T) {
 		"--rollkit.da.gas_price", "1.5",
 		"--rollkit.da.mempool_ttl", "10",
 		"--rollkit.da.namespace", "namespace",
-		"--rollkit.da.start_height", "100",
 		"--rollkit.node.lazy_mode",
 		"--rollkit.node.lazy_block_interval", "2m",
 		"--rollkit.node.light",

--- a/pkg/cmd/run_node_test.go
+++ b/pkg/cmd/run_node_test.go
@@ -126,7 +126,6 @@ func TestParseFlags(t *testing.T) {
 		{"DAGasPrice", nodeConfig.DA.GasPrice, 1.5},
 		{"DAMempoolTTL", nodeConfig.DA.MempoolTTL, uint64(10)},
 		{"DANamespace", nodeConfig.DA.Namespace, "namespace"},
-		{"DAStartHeight", nodeConfig.DA.StartHeight, uint64(100)},
 		{"LazyAggregator", nodeConfig.Node.LazyMode, true},
 		{"LazyBlockTime", nodeConfig.Node.LazyBlockInterval.Duration, 2 * time.Minute},
 		{"Light", nodeConfig.Node.Light, true},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -62,8 +62,6 @@ const (
 	FlagDAGasPrice = FlagPrefixEvnode + "da.gas_price"
 	// FlagDAGasMultiplier is a flag for specifying the data availability layer gas price retry multiplier
 	FlagDAGasMultiplier = FlagPrefixEvnode + "da.gas_multiplier"
-	// FlagDAStartHeight is a flag for specifying the data availability layer start height
-	FlagDAStartHeight = FlagPrefixEvnode + "da.start_height"
 	// FlagDANamespace is a flag for specifying the DA namespace ID
 	FlagDANamespace = FlagPrefixEvnode + "da.namespace"
 	// FlagDADataNamespace is a flag for specifying the DA data namespace ID
@@ -166,7 +164,6 @@ type DAConfig struct {
 	Namespace         string          `mapstructure:"namespace" yaml:"namespace" comment:"Namespace ID used when submitting blobs to the DA layer. When a DataNamespace is provided, only the header is sent to this namespace."`
 	DataNamespace     string          `mapstructure:"data_namespace" yaml:"data_namespace" comment:"Namespace ID for submitting data to DA layer. Use this to speed-up light clients."`
 	BlockTime         DurationWrapper `mapstructure:"block_time" yaml:"block_time" comment:"Average block time of the DA chain (duration). Determines frequency of DA layer syncing, maximum backoff time for retries, and is multiplied by MempoolTTL to calculate transaction expiration. Examples: \"15s\", \"30s\", \"1m\", \"2m30s\", \"10m\"."`
-	StartHeight       uint64          `mapstructure:"start_height" yaml:"start_height" comment:"Starting block height on the DA layer from which to begin syncing. Useful when deploying a new chain on an existing DA chain."`
 	MempoolTTL        uint64          `mapstructure:"mempool_ttl" yaml:"mempool_ttl" comment:"Number of DA blocks after which a transaction is considered expired and dropped from the mempool. Controls retry backoff timing."`
 	MaxSubmitAttempts int             `mapstructure:"max_submit_attempts" yaml:"max_submit_attempts" comment:"Maximum number of attempts to submit data to the DA layer before giving up. Higher values provide more resilience but can delay error reporting."`
 }
@@ -325,7 +322,6 @@ func AddFlags(cmd *cobra.Command) {
 	cmd.Flags().Duration(FlagDABlockTime, def.DA.BlockTime.Duration, "DA chain block time (for syncing)")
 	cmd.Flags().Float64(FlagDAGasPrice, def.DA.GasPrice, "DA gas price for blob transactions")
 	cmd.Flags().Float64(FlagDAGasMultiplier, def.DA.GasMultiplier, "DA gas price multiplier for retrying blob transactions")
-	cmd.Flags().Uint64(FlagDAStartHeight, def.DA.StartHeight, "starting DA block height (for syncing). If unknown, it is recommended to fetch a node's API to get it")
 	cmd.Flags().String(FlagDANamespace, def.DA.Namespace, "DA namespace for header (or blob) submissions")
 	cmd.Flags().String(FlagDADataNamespace, def.DA.DataNamespace, "DA namespace for data submissions")
 	cmd.Flags().String(FlagDASubmitOptions, def.DA.SubmitOptions, "DA submit options")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -30,7 +30,6 @@ func TestDefaultConfig(t *testing.T) {
 	assert.NotEmpty(t, def.DA.Namespace)
 	assert.Equal(t, 1*time.Second, def.Node.BlockTime.Duration)
 	assert.Equal(t, 6*time.Second, def.DA.BlockTime.Duration)
-	assert.Equal(t, uint64(0), def.DA.StartHeight)
 	assert.Equal(t, uint64(0), def.DA.MempoolTTL)
 	assert.Equal(t, uint64(0), def.Node.MaxPendingHeadersAndData)
 	assert.Equal(t, false, def.Node.LazyMode)
@@ -71,7 +70,6 @@ func TestAddFlags(t *testing.T) {
 	assertFlagValue(t, flags, FlagDABlockTime, DefaultConfig().DA.BlockTime.Duration)
 	assertFlagValue(t, flags, FlagDAGasPrice, DefaultConfig().DA.GasPrice)
 	assertFlagValue(t, flags, FlagDAGasMultiplier, DefaultConfig().DA.GasMultiplier)
-	assertFlagValue(t, flags, FlagDAStartHeight, DefaultConfig().DA.StartHeight)
 	assertFlagValue(t, flags, FlagDANamespace, DefaultConfig().DA.Namespace)
 	assertFlagValue(t, flags, FlagDASubmitOptions, DefaultConfig().DA.SubmitOptions)
 	assertFlagValue(t, flags, FlagDAMempoolTTL, DefaultConfig().DA.MempoolTTL)
@@ -105,7 +103,7 @@ func TestAddFlags(t *testing.T) {
 	assertFlagValue(t, flags, FlagRPCAddress, DefaultConfig().RPC.Address)
 
 	// Count the number of flags we're explicitly checking
-	expectedFlagCount := 39 // Update this number if you add more flag checks above
+	expectedFlagCount := 38 // Update this number if you add more flag checks above
 
 	// Get the actual number of flags (both regular and persistent)
 	actualFlagCount := 0

--- a/pkg/genesis/genesis.go
+++ b/pkg/genesis/genesis.go
@@ -15,6 +15,7 @@ type Genesis struct {
 	StartTime       time.Time `json:"start_time"`
 	InitialHeight   uint64    `json:"initial_height"`
 	ProposerAddress []byte    `json:"proposer_address"`
+	DAStartHeight   uint64    `json:"da_start_height"`
 }
 
 // NewGenesis creates a new Genesis instance.

--- a/pkg/genesis/genesis.go
+++ b/pkg/genesis/genesis.go
@@ -30,6 +30,7 @@ func NewGenesis(
 		StartTime:       startTime,
 		InitialHeight:   initialHeight,
 		ProposerAddress: proposerAddress,
+		DAStartHeight:   0,
 	}
 
 	return genesis


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

UX improvement to move da height from user config to developer config.
The flow is as follow:

The developer once starting is sequencer is able to query its node to get the da start height
They should add it in the genesis they share with the others node operators.
Nodes will fetch directly from the correct DA height. 

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->
