### PR TITLE
chore: use released ev-node module in apps

### DIFF
--- a/apps/evm/go.mod
+++ b/apps/evm/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	github.com/ethereum/go-ethereum v1.17.5
-	github.com/evstack/ev-node v1.2.2
+	github.com/evstack/ev-node v1.2.3
 	github.com/evstack/ev-node/core v1.1.0
 	github.com/evstack/ev-node/execution/evm v1.1.1
 	github.com/ipfs/go-datastore v0.9.2
@@ -235,5 +235,3 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/blake3 v1.4.1 // indirect
 )
-
-replace github.com/evstack/ev-node => ../..

--- a/apps/evm/go.sum
+++ b/apps/evm/go.sum
@@ -183,6 +183,8 @@ github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab h1:rvv6MJ
 github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab/go.mod h1:IuLm4IsPipXKF7CW5Lzf68PIbZ5yl7FFd74l/E0o9A8=
 github.com/ethereum/go-ethereum v1.17.5 h1:o9BIXs2Q/3cPHVxw49n+Zjn2i6rB9TOXatev46duOC4=
 github.com/ethereum/go-ethereum v1.17.5/go.mod h1:vz2YvG7RewA4sFHTgzLyW+WmFG1N4jfk/hgXQVhhn9c=
+github.com/evstack/ev-node v1.2.3 h1:yfUmHE43evpLHQu8pKvGoEVfIq2AbxYiRnXYcI7kYSA=
+github.com/evstack/ev-node v1.2.3/go.mod h1:OQLzVtHXYVH1RzHjuLClFYlYG2NJhZF1iFYIhN7z96g=
 github.com/evstack/ev-node/core v1.1.0 h1:Sa7uU5yuNF7YUyLBHPThD6Jt8/jacM1epRLATrdvKRE=
 github.com/evstack/ev-node/core v1.1.0/go.mod h1:n2w/LhYQTPsi48m6lMj16YiIqsaQw6gxwjyJvR+B3sY=
 github.com/evstack/ev-node/execution/evm v1.1.1 h1:erBo0do2Ipw/kyHeoHdjkTpNT6/dGgbxyZZsZlCw0r0=

--- a/apps/testapp/go.mod
+++ b/apps/testapp/go.mod
@@ -3,7 +3,7 @@ module github.com/evstack/ev-node/apps/testapp
 go 1.25.8
 
 require (
-	github.com/evstack/ev-node v1.2.2
+	github.com/evstack/ev-node v1.2.3
 	github.com/evstack/ev-node/core v1.1.0
 	github.com/ipfs/go-datastore v0.9.2
 	github.com/rs/zerolog v1.35.1
@@ -209,5 +209,3 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/blake3 v1.4.1 // indirect
 )
-
-replace github.com/evstack/ev-node => ../..

--- a/apps/testapp/go.sum
+++ b/apps/testapp/go.sum
@@ -132,6 +132,8 @@ github.com/envoyproxy/go-control-plane/envoy v1.37.0/go.mod h1:DReE9MMrmecPy+YvQ
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v1.3.3 h1:MVQghNeW+LZcmXe7SY1V36Z+WFMDjpqGAGacLe2T0ds=
 github.com/envoyproxy/protoc-gen-validate v1.3.3/go.mod h1:TsndJ/ngyIdQRhMcVVGDDHINPLWB7C82oDArY51KfB0=
+github.com/evstack/ev-node v1.2.3 h1:yfUmHE43evpLHQu8pKvGoEVfIq2AbxYiRnXYcI7kYSA=
+github.com/evstack/ev-node v1.2.3/go.mod h1:OQLzVtHXYVH1RzHjuLClFYlYG2NJhZF1iFYIhN7z96g=
 github.com/evstack/ev-node/core v1.1.0 h1:Sa7uU5yuNF7YUyLBHPThD6Jt8/jacM1epRLATrdvKRE=
 github.com/evstack/ev-node/core v1.1.0/go.mod h1:n2w/LhYQTPsi48m6lMj16YiIqsaQw6gxwjyJvR+B3sY=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=


### PR DESCRIPTION
## What changed

- Update `apps/evm` and `apps/testapp` to use the published `github.com/evstack/ev-node v1.2.3` module.
- Remove their local root-module `replace` directives.
- Record the v1.2.3 module checksums.

## Why

The root v1.2.3 release is now published, so these app modules can resolve the released dependency instead of relying on the monorepo checkout. Test-only local replacements remain unchanged.

## Validation

- `go test ./...` in `apps/evm`
- `go test ./...` in `apps/testapp`
- `go mod verify` in both modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated the application integration to use ev-node v1.2.3.
  * Removed local development overrides so builds use the published dependency version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->