### PR TITLE
refactor(loadgen): use WaitGroup.Go for scheduled workloads

### DIFF
--- a/apps/loadgen/cmd/start.go
+++ b/apps/loadgen/cmd/start.go
@@ -78,7 +78,6 @@ func runScheduler(parent context.Context, cfg startConfig) error {
 
 	var wg sync.WaitGroup
 	runWorkload := func(label, matrixPath string, txCount int) {
-		defer wg.Done()
 		log.Printf("==> %s workload starting (%d tx)", label, txCount)
 		if err := runner.ExecuteMatrixWithOverridesFromFile(ctx, matrixPath, api, txCount); err != nil {
 			log.Printf("%s workload error: %v", label, err)
@@ -86,8 +85,7 @@ func runScheduler(parent context.Context, cfg startConfig) error {
 	}
 
 	// fire regular immediately
-	wg.Add(1)
-	go runWorkload("regular", cfg.regularMatrix, regularTxPerRun)
+	wg.Go(func() { runWorkload("regular", cfg.regularMatrix, regularTxPerRun) })
 
 	ticker := time.NewTicker(cfg.interval)
 	defer ticker.Stop()
@@ -112,12 +110,10 @@ func runScheduler(parent context.Context, cfg startConfig) error {
 			return nil
 
 		case <-ticker.C:
-			wg.Add(1)
-			go runWorkload("regular", cfg.regularMatrix, regularTxPerRun)
+			wg.Go(func() { runWorkload("regular", cfg.regularMatrix, regularTxPerRun) })
 
 		case <-burstTimer.C:
-			wg.Add(1)
-			go runWorkload("burst", cfg.burstMatrix, cfg.burstTxCount)
+			wg.Go(func() { runWorkload("burst", cfg.burstMatrix, cfg.burstTxCount) })
 			burstsRemaining--
 			burstTimer = nextBurstTimer(burstsRemaining, time.Until(nextReset))
 


### PR DESCRIPTION
## Overview

Replace manual `WaitGroup.Add`/`Done` wrappers with `WaitGroup.Go` for immediate, regular, and burst load-generator workloads. This keeps goroutine creation and lifecycle accounting together without changing scheduling, workload parameters, or completion behavior.

More info: https://github.com/golang/go/issues/63796


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal workload scheduling and concurrency management.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->