### PR TITLE
ci: build and test with Go 1.27

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version-file: ./go.mod
+          go-version: "1.27.0"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Install just
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version-file: ./go.mod
+          go-version: "1.27.0"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Install just
@@ -87,7 +87,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version-file: ./go.mod
+          go-version: "1.27.0"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Install just
@@ -109,7 +109,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version-file: ./go.mod
+          go-version: "1.27.0"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Install just
@@ -132,7 +132,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version-file: ./go.mod
+          go-version: "1.27.0"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Install just

--- a/.github/workflows/dependabot-auto-fix.yml
+++ b/.github/workflows/dependabot-auto-fix.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-go@v6.5.0
         with:
-          go-version-file: ./go.mod
+          go-version: "1.27.0"
 
       - name: Install just
         uses: extractions/setup-just@v4

--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v6.5.0
         with:
-          go-version-file: ./test/docker-e2e/go.mod
+          go-version: "1.27.0"
           cache-dependency-path: "**/go.sum"
       - name: Install just
         uses: extractions/setup-just@v4
@@ -46,7 +46,7 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v6.5.0
         with:
-          go-version-file: ./test/docker-e2e/go.mod
+          go-version: "1.27.0"
           cache-dependency-path: "**/go.sum"
       - name: Install just
         uses: extractions/setup-just@v4
@@ -66,7 +66,7 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v6.5.0
         with:
-          go-version-file: ./test/docker-e2e/go.mod
+          go-version: "1.27.0"
           cache-dependency-path: "**/go.sum"
       - name: Install just
         uses: extractions/setup-just@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v7.0.1
       - uses: actions/setup-go@v6.5.0
         with:
-          go-version-file: ./go.mod
+          go-version: "1.27.0"
           cache-dependency-path: "**/go.sum"
       # This steps sets the GIT_DIFF environment variable to true
       # if files defined in PATTERS changed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v6.5.0
         with:
-          go-version-file: ./go.mod
+          go-version: "1.27.0"
           cache-dependency-path: "**/go.sum"
       - name: Install just
         uses: extractions/setup-just@v4
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v7.0.1
       - uses: actions/setup-go@v6.5.0
         with:
-          go-version-file: ./go.mod
+          go-version: "1.27.0"
           cache-dependency-path: "**/go.sum"
       - uses: extractions/setup-just@v4
       - run: just deps
@@ -48,7 +48,7 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v6.5.0
         with:
-          go-version-file: ./go.mod
+          go-version: "1.27.0"
           cache-dependency-path: "**/go.sum"
       - name: Install just
         uses: extractions/setup-just@v4
@@ -68,7 +68,7 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v6.5.0
         with:
-          go-version-file: ./go.mod
+          go-version: "1.27.0"
           cache-dependency-path: "**/go.sum"
       - name: Install just
         uses: extractions/setup-just@v4
@@ -92,7 +92,7 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v6.5.0
         with:
-          go-version-file: ./go.mod
+          go-version: "1.27.0"
           cache-dependency-path: "**/go.sum"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -119,7 +119,7 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v6.5.0
         with:
-          go-version-file: ./go.mod
+          go-version: "1.27.0"
           cache-dependency-path: "**/go.sum"
       - name: Install just
         uses: extractions/setup-just@v4

--- a/apps/evm/Dockerfile
+++ b/apps/evm/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine AS build-env
+FROM golang:1.27.0-alpine AS build-env
 
 WORKDIR /src
 

--- a/apps/loadgen/Dockerfile
+++ b/apps/loadgen/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS build-env
+FROM golang:1.27.0-alpine AS build-env
 
 WORKDIR /src
 

--- a/apps/testapp/Dockerfile
+++ b/apps/testapp/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26 AS base
+FROM golang:1.27.0 AS base
 
 #hadolint ignore=DL3018
 RUN apt-get update && \

--- a/tools/local-da/Dockerfile
+++ b/tools/local-da/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine AS build-env
+FROM golang:1.27.0-alpine AS build-env
 
 WORKDIR /src
 


### PR DESCRIPTION
## Overview

- Pin all GitHub Actions Go setup steps to Go 1.27.0.
- Pin the testapp builder to golang:1.27.0.
- Pin the EVM, loadgen, and local-DA builders to golang:1.27.0-alpine.
- Keep module Go directives and runtime Alpine images unchanged.

## Verification

- just build-all
- just test
- yamllint --no-warnings . -c .yamllint.yml
- git diff --check

Not run locally: actionlint and hadolint were not installed. Docker builds were left to CI so the new base images were not pulled locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the Go toolchain to version 1.27.0 across CI workflows and Docker build images.
  * Standardized Go version usage in test, lint, benchmark, and dependency automation jobs.
  * Updated container build environments to keep local and CI builds aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->