### PR TITLE
test(config): rename legacy IP fixture

### DIFF
--- a/pkg/config/addr_test.go
+++ b/pkg/config/addr_test.go
@@ -12,7 +12,7 @@ func TestTranslateAddresses(t *testing.T) {
 	t.Parallel()
 
 	invalidCosmos := "foobar"
-	legactIP := "127.0.0.1:1234"
+	legacyIP := "127.0.0.1:1234"
 	validIP := "/ip4/127.0.0.1/tcp/1234"
 
 	cases := []struct {
@@ -24,13 +24,13 @@ func TestTranslateAddresses(t *testing.T) {
 		{"empty", Config{}, Config{}, ""},
 		{
 			"valid listen address",
-			Config{P2P: P2PConfig{ListenAddress: legactIP}},
+			Config{P2P: P2PConfig{ListenAddress: legacyIP}},
 			Config{P2P: P2PConfig{ListenAddress: validIP}},
 			"",
 		},
 		{
 			"valid seed address",
-			Config{P2P: P2PConfig{Peers: legactIP + "," + legactIP}},
+			Config{P2P: P2PConfig{Peers: legacyIP + "," + legacyIP}},
 			Config{P2P: P2PConfig{Peers: validIP + "," + validIP}},
 			"",
 		},
@@ -42,7 +42,7 @@ func TestTranslateAddresses(t *testing.T) {
 		},
 		{
 			"invalid seed address",
-			Config{P2P: P2PConfig{Peers: legactIP + "," + invalidCosmos}},
+			Config{P2P: P2PConfig{Peers: legacyIP + "," + invalidCosmos}},
 			Config{},
 			errInvalidAddress.Error(),
 		},


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

Rename the misspelled `legactIP` test fixture to `legacyIP` in the P2P address validation cases. This is a test-only readability improvement with no behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Corrected a test variable name for improved clarity.
  * No functional or behavioral changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->