### PR TITLE
test(evm): use typed sorting for trace totals

### DIFF
--- a/pkg/store/store_adapter.go
+++ b/pkg/store/store_adapter.go
@@ -445,13 +445,13 @@ func (a *StoreAdapter[H]) Get(ctx context.Context, hash header.Hash) (H, error) 
 	// First try the store
 	item, err := a.getter.GetByHash(ctx, hash)
 	if err == nil {
-		a.applyDAHint(item)
+		a.applyDAHint(ctx, item)
 		return item, nil
 	}
 
 	// Check pending items using hash index for O(1) lookup
 	if pendingItem, ok := a.pending.getByHash(hash); ok {
-		a.applyDAHint(pendingItem)
+		a.applyDAHint(ctx, pendingItem)
 		return pendingItem, nil
 	}
 
@@ -485,13 +485,13 @@ func (a *StoreAdapter[H]) getByHeightNoWait(ctx context.Context, height uint64) 
 	// First try the store
 	item, err := a.getter.GetByHeight(ctx, height)
 	if err == nil {
-		a.applyDAHint(item)
+		a.applyDAHint(ctx, item)
 		return item, nil
 	}
 
 	// Check pending items
 	if pendingItem, ok := a.pending.get(height); ok {
-		a.applyDAHint(pendingItem)
+		a.applyDAHint(ctx, pendingItem)
 		return pendingItem, nil
 	}
 
@@ -499,7 +499,7 @@ func (a *StoreAdapter[H]) getByHeightNoWait(ctx context.Context, height uint64) 
 }
 
 // applyDAHint sets the DA hint on the item from cache or disk.
-func (a *StoreAdapter[H]) applyDAHint(item H) {
+func (a *StoreAdapter[H]) applyDAHint(ctx context.Context, item H) {
 	if item.IsZero() {
 		return
 	}
@@ -513,7 +513,7 @@ func (a *StoreAdapter[H]) applyDAHint(item H) {
 	}
 
 	// Try to load from disk
-	if diskHint, err := a.getter.GetDAHint(context.Background(), height); err == nil && diskHint > 0 {
+	if diskHint, err := a.getter.GetDAHint(ctx, height); err == nil && diskHint > 0 {
 		a.pending.setDAHint(height, diskHint)
 		item.SetDAHint(diskHint)
 	}

--- a/test/e2e/evm_test_common.go
+++ b/test/e2e/evm_test_common.go
@@ -15,6 +15,7 @@
 package e2e
 
 import (
+	"cmp"
 	"context"
 	"flag"
 	"fmt"
@@ -23,7 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -904,8 +905,8 @@ func PrintTraceReport(t testing.TB, label string, spans []TraceSpan) {
 	for name := range m {
 		names = append(names, name)
 	}
-	sort.Slice(names, func(i, j int) bool {
-		return m[names[i]].Total > m[names[j]].Total
+	slices.SortFunc(names, func(a, b string) int {
+		return cmp.Compare(m[b].Total, m[a].Total)
 	})
 
 	var overallTotal time.Duration


### PR DESCRIPTION

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


Use slices.SortFunc with a typed comparator when ordering aggregated EVM trace names by total duration. 

The report remains in descending duration order while the comparator works directly with names instead of slice indices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data availability hint loading so request cancellation and deadlines are respected.
* **Tests**
  * Updated trace report sorting to produce clearer and more consistent output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->