### PR TITLE
fix(execution): clear omitted payload envelope optionals

### DIFF
--- a/execution/evm/engine_payload.go
+++ b/execution/evm/engine_payload.go
@@ -85,15 +85,14 @@ func (e *EnginePayloadEnvelope) UnmarshalJSON(input []byte) error {
 	e.BlockValue = (*big.Int)(dec.BlockValue)
 	e.BlobsBundle = dec.BlobsBundle
 
+	e.Requests = nil
 	if dec.Requests != nil {
 		e.Requests = make([][]byte, len(dec.Requests))
 		for i, request := range dec.Requests {
 			e.Requests[i] = request
 		}
 	}
-	if dec.Override != nil {
-		e.Override = *dec.Override
-	}
+	e.Override = dec.Override != nil && *dec.Override
 	e.Witness = dec.Witness
 	return nil
 }

--- a/execution/evm/engine_rpc_client_test.go
+++ b/execution/evm/engine_rpc_client_test.go
@@ -573,6 +573,29 @@ func TestEnginePayloadEnvelope_MarshalJSON_UsesWireFieldNames(t *testing.T) {
 	require.JSONEq(t, string(envelope.RawExecutionPayload), string(decoded.RawExecutionPayload))
 }
 
+func TestEnginePayloadEnvelope_UnmarshalClearsOmittedFields(t *testing.T) {
+	withOptionals := strings.ReplaceAll(minimalPayloadEnvelopeJSON,
+		`"executionRequests": []`, `"executionRequests": ["0x01"]`)
+	withOptionals = strings.ReplaceAll(withOptionals,
+		`"shouldOverrideBuilder": false`, `"shouldOverrideBuilder": true`)
+
+	var envelope EnginePayloadEnvelope
+	require.NoError(t, json.Unmarshal([]byte(withOptionals), &envelope))
+	require.NotEmpty(t, envelope.Requests)
+	require.True(t, envelope.Override)
+
+	var withoutOptionals map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(minimalPayloadEnvelopeJSON), &withoutOptionals))
+	delete(withoutOptionals, "executionRequests")
+	delete(withoutOptionals, "shouldOverrideBuilder")
+	encoded, err := json.Marshal(withoutOptionals)
+	require.NoError(t, err)
+
+	require.NoError(t, json.Unmarshal(encoded, &envelope))
+	require.Nil(t, envelope.Requests)
+	require.False(t, envelope.Override)
+}
+
 func TestIsUnsupportedForkErr(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

When an Engine API payload envelope is decoded into a reused object, omitted Requests/Override fields can retain values from an earlier response. I propose clearing those optionals during decoding and adding a regression test in execution/evm.



Clear stale `Requests` and `Override` optionals when an Engine API payload envelope is reused, and add regression coverage for the reuse case.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected payload processing so omitted execution request and builder override fields are properly reset when decoding new data.
  * Prevented stale values from being carried over between payloads.

* **Tests**
  * Added coverage verifying field population when values are provided and clearing when they are omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->