### PR TITLE
fix(store): remove canceled height waiters

### DIFF
--- a/pkg/store/store_adapter.go
+++ b/pkg/store/store_adapter.go
@@ -104,7 +104,34 @@ func (hs *heightSub) Wait(ctx context.Context, height uint64) error {
 	case <-ch:
 		return nil
 	case <-ctx.Done():
+		hs.removeWaiter(height, ch)
 		return ctx.Err()
+	}
+}
+
+// removeWaiter unregisters a specific waiter from the requested height.
+func (hs *heightSub) removeWaiter(height uint64, target chan struct{}) {
+	hs.heightMu.Lock()
+	defer hs.heightMu.Unlock()
+
+	chs, ok := hs.heightChs[height]
+	if !ok {
+		return
+	}
+
+	for i, ch := range chs {
+		if ch != target {
+			continue
+		}
+		copy(chs[i:], chs[i+1:])
+		chs[len(chs)-1] = nil
+		chs = chs[:len(chs)-1]
+		if len(chs) == 0 {
+			delete(hs.heightChs, height)
+		} else {
+			hs.heightChs[height] = chs
+		}
+		return
 	}
 }
 

--- a/pkg/store/store_adapter_test.go
+++ b/pkg/store/store_adapter_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -309,6 +310,97 @@ func TestPendingCache_ConcurrentAccess(t *testing.T) {
 
 	// Should not panic and should have some items remaining
 	assert.GreaterOrEqual(t, cache.len(), 0)
+}
+
+func TestHeightSubWaitCancellationRemovesWaiter(t *testing.T) {
+	t.Parallel()
+
+	hs := newHeightSub(1)
+	for range 100 {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		require.ErrorIs(t, hs.Wait(ctx, 1_000), context.Canceled)
+	}
+
+	hs.heightMu.Lock()
+	defer hs.heightMu.Unlock()
+	assert.Empty(t, hs.heightChs)
+}
+
+func TestHeightSubWaitCancellationPreservesOtherWaiters(t *testing.T) {
+	t.Parallel()
+
+	hs := newHeightSub(1)
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	ctx2 := context.Background()
+	waitDone := make(chan error, 2)
+	go func() {
+		waitDone <- hs.Wait(ctx1, 1_000)
+	}()
+	go func() {
+		waitDone <- hs.Wait(ctx2, 1_000)
+	}()
+
+	require.Eventually(t, func() bool {
+		hs.heightMu.Lock()
+		defer hs.heightMu.Unlock()
+		return len(hs.heightChs[1_000]) == 2
+	}, time.Second, time.Millisecond)
+
+	cancel1()
+	require.Eventually(t, func() bool {
+		hs.heightMu.Lock()
+		defer hs.heightMu.Unlock()
+		return len(hs.heightChs[1_000]) == 1
+	}, time.Second, time.Millisecond)
+
+	hs.SetHeight(1_000)
+	results := []error{<-waitDone, <-waitDone}
+	assert.Contains(t, results, context.Canceled)
+	assert.Contains(t, results, nil)
+}
+
+func TestHeightSubWaitCancellationAndSetHeightConcurrent(t *testing.T) {
+	t.Parallel()
+
+	for range 100 {
+		hs := newHeightSub(1)
+		ctx, cancel := context.WithCancel(context.Background())
+		waitDone := make(chan error, 1)
+		go func() {
+			waitDone <- hs.Wait(ctx, 1_000)
+		}()
+
+		// Ensure the waiter is registered before racing cancellation and notification.
+		require.Eventually(t, func() bool {
+			hs.heightMu.Lock()
+			defer hs.heightMu.Unlock()
+			return len(hs.heightChs[1_000]) == 1
+		}, time.Second, time.Millisecond)
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			cancel()
+		}()
+		go func() {
+			defer wg.Done()
+			hs.SetHeight(1_000)
+		}()
+		wg.Wait()
+
+		err := <-waitDone
+		if err != nil {
+			assert.ErrorIs(t, err, context.Canceled)
+		}
+
+		cancel()
+		hs.heightMu.Lock()
+		assert.Empty(t, hs.heightChs)
+		hs.heightMu.Unlock()
+	}
 }
 
 // TestStoreAdapter_Backpressure tests that Append blocks when cache is full


### PR DESCRIPTION
## Overview

Closes  https://github.com/evstack/ev-node/issues/3444

`heightSub.Wait` registers a channel for every requested height, but the context-cancellation path did not unregister it. For heights that are never reached, canceled waiters remained referenced by `heightChs`, causing stale channels to accumulate during normal P2P sync cancellation and timeout lifecycles.

This change:

- removes the specific canceled waiter under `heightMu`;
- preserves other waiters registered for the same height;
- handles cancellation racing with `notifyUpTo`;
- adds regression tests for cleanup and concurrent cancellation/notification.

Tests:

- `go test ./pkg/store`
- `go test -race ./pkg/store -run 'TestHeightSubWaitCancellation' -count=10`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of canceled height waits to prevent stale internal waiters from accumulating.
  - Preserved notifications for other active waiters when one wait is canceled.
  - Improved reliability when cancellation and height updates occur concurrently.

- **Tests**
  - Added coverage for canceled waits, multiple waiters, and concurrent cancellation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->