### PR TITLE
fix(evm): restore forkchoice state on restart

### DIFF
--- a/execution/evm/execution.go
+++ b/execution/evm/execution.go
@@ -186,6 +186,7 @@ type EngineClient struct {
 	currentSafeBlockHash      common.Hash            // Store last non-finalized SafeBlockHash
 	currentFinalizedBlockHash common.Hash            // Store last finalized block hash
 	blockHashCache            map[uint64]common.Hash // height -> hash cache for safe block lookups
+	forkchoiceInitialized     bool                   // Whether forkchoice state was restored from the execution layer
 
 	cachedExecutionInfo atomic.Pointer[execution.ExecutionInfo] // Cached execution info (gas limit)
 
@@ -310,6 +311,18 @@ func (c *EngineClient) InitChain(ctx context.Context, genesisTime time.Time, ini
 		return nil, err
 	}
 
+	c.mu.Lock()
+	c.currentHeadBlockHash = c.genesisHash
+	c.currentHeadHeight = 0
+	c.currentSafeBlockHash = c.genesisHash
+	c.currentFinalizedBlockHash = c.genesisHash
+	if c.blockHashCache == nil {
+		c.blockHashCache = make(map[uint64]common.Hash)
+	}
+	c.blockHashCache[0] = c.genesisHash
+	c.forkchoiceInitialized = true
+	c.mu.Unlock()
+
 	_, stateRoot, _, _, err := c.getBlockInfo(ctx, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get block info: %w", err)
@@ -342,6 +355,96 @@ func (c *EngineClient) GetTxs(ctx context.Context) ([][]byte, error) {
 	return txs, nil
 }
 
+// ensureForkchoiceInitialized restores the forkchoice state persisted by the
+// execution layer. Initialization is serialized and remains retryable until all
+// required block tags have been read and validated successfully.
+func (c *EngineClient) ensureForkchoiceInitialized(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.forkchoiceInitialized {
+		return nil
+	}
+
+	latest, latestErr := c.headerByBlockTag(ctx, rpc.LatestBlockNumber)
+	safe, safeErr := c.headerByBlockTag(ctx, rpc.SafeBlockNumber)
+	finalized, finalizedErr := c.headerByBlockTag(ctx, rpc.FinalizedBlockNumber)
+	if latestErr != nil {
+		return latestErr
+	}
+
+	headHeight := latest.Number.Uint64()
+	if headHeight == 0 {
+		if latest.Hash() != c.genesisHash {
+			return fmt.Errorf("latest genesis hash %s does not match configured genesis hash %s", latest.Hash(), c.genesisHash)
+		}
+
+		// Some execution clients do not expose safe/finalized tags until their
+		// first forkchoice update. A genesis-only chain has no state to recover
+		// beyond the configured genesis hash.
+		c.currentHeadBlockHash = c.genesisHash
+		c.currentHeadHeight = 0
+		c.currentSafeBlockHash = c.genesisHash
+		c.currentFinalizedBlockHash = c.genesisHash
+		if c.blockHashCache == nil {
+			c.blockHashCache = make(map[uint64]common.Hash)
+		}
+		c.blockHashCache[0] = c.genesisHash
+		c.forkchoiceInitialized = true
+		return nil
+	}
+
+	if safeErr != nil {
+		return safeErr
+	}
+	if finalizedErr != nil {
+		return finalizedErr
+	}
+
+	safeHeight := safe.Number.Uint64()
+	finalizedHeight := finalized.Number.Uint64()
+	if finalizedHeight > safeHeight || safeHeight > headHeight {
+		return fmt.Errorf("inconsistent forkchoice heights: finalized=%d safe=%d head=%d", finalizedHeight, safeHeight, headHeight)
+	}
+	if safeHeight == headHeight && safe.Hash() != latest.Hash() {
+		return fmt.Errorf("inconsistent forkchoice hashes at head height %d", headHeight)
+	}
+	if finalizedHeight == safeHeight && finalized.Hash() != safe.Hash() {
+		return fmt.Errorf("inconsistent forkchoice hashes at safe height %d", safeHeight)
+	}
+
+	c.currentHeadBlockHash = latest.Hash()
+	c.currentHeadHeight = headHeight
+	c.currentSafeBlockHash = safe.Hash()
+	c.currentFinalizedBlockHash = finalized.Hash()
+	if c.blockHashCache == nil {
+		c.blockHashCache = make(map[uint64]common.Hash)
+	}
+	c.blockHashCache[headHeight] = latest.Hash()
+	c.blockHashCache[safeHeight] = safe.Hash()
+	c.blockHashCache[finalizedHeight] = finalized.Hash()
+	c.forkchoiceInitialized = true
+
+	c.logger.Info().
+		Uint64("head_height", headHeight).
+		Uint64("safe_height", safeHeight).
+		Uint64("finalized_height", finalizedHeight).
+		Msg("restored forkchoice state from execution layer")
+
+	return nil
+}
+
+func (c *EngineClient) headerByBlockTag(ctx context.Context, tag rpc.BlockNumber) (*types.Header, error) {
+	header, err := c.ethClient.HeaderByNumber(ctx, big.NewInt(tag.Int64()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get %s block: %w", tag.String(), err)
+	}
+	if header == nil || header.Number == nil {
+		return nil, fmt.Errorf("execution layer returned missing %s block", tag.String())
+	}
+	return header, nil
+}
+
 // ExecuteTxs executes the given transactions at the specified block height and timestamp.
 //
 // ExecMeta tracking (if store is configured):
@@ -349,6 +452,9 @@ func (c *EngineClient) GetTxs(ctx context.Context) ([][]byte, error) {
 // - Saves ExecMeta with payloadID after forkchoiceUpdatedV3 for crash recovery
 // - Updates ExecMeta to "promoted" after successful execution
 func (c *EngineClient) ExecuteTxs(ctx context.Context, txs [][]byte, blockHeight uint64, timestamp time.Time, prevStateRoot []byte) (execution.ExecuteResult, error) {
+	if err := c.ensureForkchoiceInitialized(ctx); err != nil {
+		return execution.ExecuteResult{}, fmt.Errorf("initialize forkchoice state: %w", err)
+	}
 
 	// 1. Check for idempotent execution
 	stateRoot, payloadID, found, idempotencyErr := c.reconcileExecutionAtHeight(ctx, blockHeight, timestamp, txs)
@@ -459,6 +565,10 @@ func (c *EngineClient) ExecuteTxs(ctx context.Context, txs [][]byte, blockHeight
 // setHead updates the head block hash without changing safe or finalized.
 // This is used when reusing an existing block (idempotency check).
 func (c *EngineClient) setHead(ctx context.Context, blockHash common.Hash) error {
+	if err := c.ensureForkchoiceInitialized(ctx); err != nil {
+		return fmt.Errorf("initialize forkchoice state: %w", err)
+	}
+
 	c.mu.Lock()
 	c.currentHeadBlockHash = blockHash
 	// Note: safe and finalized are NOT updated - they advance separately via derivation
@@ -483,6 +593,10 @@ func (c *EngineClient) setFinal(ctx context.Context, blockHash common.Hash, isFi
 //
 // Note: The finalized lag is a temporary mock until proper DA-based finalization is wired up.
 func (c *EngineClient) setFinalWithHeight(ctx context.Context, blockHash common.Hash, headHeight uint64, isFinal bool) error {
+	if err := c.ensureForkchoiceInitialized(ctx); err != nil {
+		return fmt.Errorf("initialize forkchoice state: %w", err)
+	}
+
 	var safeHash, finalizedHash common.Hash
 	updateSafe := !isFinal && headHeight > SafeBlockLag
 	updateFinalized := !isFinal && headHeight > FinalizedBlockLag
@@ -597,6 +711,10 @@ func (c *EngineClient) SetFinal(ctx context.Context, blockHeight uint64) error {
 // This allows the derivation layer to advance the safe block independently of head.
 // Safe indicates a block that is unlikely to be reorged (e.g., confirmed by DA).
 func (c *EngineClient) SetSafe(ctx context.Context, blockHash common.Hash) error {
+	if err := c.ensureForkchoiceInitialized(ctx); err != nil {
+		return fmt.Errorf("initialize forkchoice state: %w", err)
+	}
+
 	c.mu.Lock()
 	c.currentSafeBlockHash = blockHash
 	args := engine.ForkchoiceStateV1{
@@ -663,6 +781,10 @@ func (c *EngineClient) cacheBlockHash(height uint64, hash common.Hash) {
 // This allows the derivation layer to advance finalization independently.
 // Finalized indicates a block that will never be reorged (e.g., included in DA with sufficient confirmations).
 func (c *EngineClient) SetFinalized(ctx context.Context, blockHash common.Hash) error {
+	if err := c.ensureForkchoiceInitialized(ctx); err != nil {
+		return fmt.Errorf("initialize forkchoice state: %w", err)
+	}
+
 	c.mu.Lock()
 	c.currentFinalizedBlockHash = blockHash
 	// Finalized implies safe.
@@ -684,6 +806,9 @@ func (c *EngineClient) SetFinalized(ctx context.Context, blockHash common.Hash) 
 // Returns the state root from the payload, or an error if resumption fails.
 // Implements the execution.PayloadResumer interface.
 func (c *EngineClient) ResumePayload(ctx context.Context, payloadIDBytes []byte) (stateRoot []byte, err error) {
+	if err := c.ensureForkchoiceInitialized(ctx); err != nil {
+		return nil, fmt.Errorf("initialize forkchoice state: %w", err)
+	}
 
 	// Convert bytes to PayloadID
 	if len(payloadIDBytes) != 8 {
@@ -1151,6 +1276,10 @@ func (c *EngineClient) GetLatestHeight(ctx context.Context) (uint64, error) {
 //
 // Implements the execution.Rollbackable interface.
 func (c *EngineClient) Rollback(ctx context.Context, targetHeight uint64) error {
+	if err := c.ensureForkchoiceInitialized(ctx); err != nil {
+		return fmt.Errorf("initialize forkchoice state: %w", err)
+	}
+
 	// Get block hash at target height
 	blockHash, _, _, _, err := c.getBlockInfo(ctx, targetHeight)
 	if err != nil {

--- a/execution/evm/forkchoice_init_test.go
+++ b/execution/evm/forkchoice_init_test.go
@@ -1,0 +1,297 @@
+package evm
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/beacon/engine"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
+	ds "github.com/ipfs/go-datastore"
+	dssync "github.com/ipfs/go-datastore/sync"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureForkchoiceInitializedRestoresExecutionLayerState(t *testing.T) {
+	head := forkchoiceTestHeader(8, 8)
+	safe := forkchoiceTestHeader(6, 6)
+	finalized := forkchoiceTestHeader(4, 4)
+	ethRPC := newForkchoiceTestEthRPC(head, safe, finalized)
+	client := newForkchoiceTestClient(ethRPC, &forkchoiceTestEngineRPC{})
+
+	require.NoError(t, client.ensureForkchoiceInitialized(t.Context()))
+	require.Equal(t, head.Hash(), client.currentHeadBlockHash)
+	require.Equal(t, uint64(8), client.currentHeadHeight)
+	require.Equal(t, safe.Hash(), client.currentSafeBlockHash)
+	require.Equal(t, finalized.Hash(), client.currentFinalizedBlockHash)
+	require.Equal(t, head.Hash(), client.blockHashCache[8])
+	require.Equal(t, safe.Hash(), client.blockHashCache[6])
+	require.Equal(t, finalized.Hash(), client.blockHashCache[4])
+	require.Equal(t, 1, ethRPC.callsFor(rpc.LatestBlockNumber.Int64()))
+	require.Equal(t, 1, ethRPC.callsFor(rpc.SafeBlockNumber.Int64()))
+	require.Equal(t, 1, ethRPC.callsFor(rpc.FinalizedBlockNumber.Int64()))
+}
+
+func TestExecuteTxsFirstForkchoiceUsesRestoredSafeAndFinalized(t *testing.T) {
+	head := forkchoiceTestHeader(5, 5)
+	safe := forkchoiceTestHeader(4, 4)
+	finalized := forkchoiceTestHeader(3, 3)
+	next := forkchoiceTestHeader(6, 6)
+	ethRPC := newForkchoiceTestEthRPC(head, safe, finalized)
+	ethRPC.headers[5] = head
+	engineRPC := &forkchoiceTestEngineRPC{
+		payload: &EnginePayloadEnvelope{ExecutionPayload: &engine.ExecutableData{
+			Number:    6,
+			Timestamp: 1_700_000_006,
+			BlockHash: next.Hash(),
+			StateRoot: common.HexToHash("0x600"),
+		}},
+	}
+	client := newForkchoiceTestClient(ethRPC, engineRPC)
+
+	_, err := client.ExecuteTxs(t.Context(), nil, 6, time.Unix(1_700_000_006, 0), head.Root.Bytes())
+	require.NoError(t, err)
+
+	states := engineRPC.forkchoiceStates()
+	require.Len(t, states, 2)
+	require.Equal(t, head.Hash(), states[0].HeadBlockHash)
+	require.Equal(t, safe.Hash(), states[0].SafeBlockHash)
+	require.Equal(t, finalized.Hash(), states[0].FinalizedBlockHash)
+}
+
+func TestSetFinalFirstOperationPreservesRestoredHead(t *testing.T) {
+	head := forkchoiceTestHeader(8, 8)
+	safe := forkchoiceTestHeader(6, 6)
+	finalized := forkchoiceTestHeader(4, 4)
+	ethRPC := newForkchoiceTestEthRPC(head, safe, finalized)
+	ethRPC.headers[6] = safe
+	engineRPC := &forkchoiceTestEngineRPC{}
+	client := newForkchoiceTestClient(ethRPC, engineRPC)
+
+	require.NoError(t, client.SetFinal(t.Context(), 6))
+
+	states := engineRPC.forkchoiceStates()
+	require.Len(t, states, 1)
+	require.Equal(t, head.Hash(), states[0].HeadBlockHash)
+	require.Equal(t, safe.Hash(), states[0].SafeBlockHash)
+	require.Equal(t, safe.Hash(), states[0].FinalizedBlockHash)
+}
+
+func TestForkchoiceInitializationConcurrentAndRetryable(t *testing.T) {
+	t.Run("concurrent callers restore once", func(t *testing.T) {
+		head := forkchoiceTestHeader(8, 8)
+		ethRPC := newForkchoiceTestEthRPC(head, forkchoiceTestHeader(6, 6), forkchoiceTestHeader(4, 4))
+		client := newForkchoiceTestClient(ethRPC, &forkchoiceTestEngineRPC{})
+
+		var wg sync.WaitGroup
+		errs := make(chan error, 12)
+		for range 12 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				errs <- client.ensureForkchoiceInitialized(t.Context())
+			}()
+		}
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			require.NoError(t, err)
+		}
+		require.Equal(t, 3, ethRPC.totalCalls())
+	})
+
+	t.Run("failed restore can be retried", func(t *testing.T) {
+		head := forkchoiceTestHeader(8, 8)
+		ethRPC := newForkchoiceTestEthRPC(head, forkchoiceTestHeader(6, 6), forkchoiceTestHeader(4, 4))
+		ethRPC.failures[rpc.SafeBlockNumber.Int64()] = 1
+		client := newForkchoiceTestClient(ethRPC, &forkchoiceTestEngineRPC{})
+
+		require.Error(t, client.ensureForkchoiceInitialized(t.Context()))
+		require.False(t, client.forkchoiceInitialized)
+		require.NoError(t, client.ensureForkchoiceInitialized(t.Context()))
+		require.True(t, client.forkchoiceInitialized)
+		require.Equal(t, 2, ethRPC.callsFor(rpc.SafeBlockNumber.Int64()))
+	})
+}
+
+func TestInvalidRestoredForkchoicePreventsUpdate(t *testing.T) {
+	tests := map[string]struct {
+		safe      *types.Header
+		finalized *types.Header
+		failTag   rpc.BlockNumber
+	}{
+		"safe above head": {
+			safe:      forkchoiceTestHeader(9, 9),
+			finalized: forkchoiceTestHeader(4, 4),
+		},
+		"finalized above safe": {
+			safe:      forkchoiceTestHeader(6, 6),
+			finalized: forkchoiceTestHeader(7, 7),
+		},
+		"safe unavailable": {
+			safe:      forkchoiceTestHeader(6, 6),
+			finalized: forkchoiceTestHeader(4, 4),
+			failTag:   rpc.SafeBlockNumber,
+		},
+		"finalized unavailable": {
+			safe:      forkchoiceTestHeader(6, 6),
+			finalized: forkchoiceTestHeader(4, 4),
+			failTag:   rpc.FinalizedBlockNumber,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ethRPC := newForkchoiceTestEthRPC(forkchoiceTestHeader(8, 8), test.safe, test.finalized)
+			if test.failTag != 0 {
+				ethRPC.failures[test.failTag.Int64()] = 1
+			}
+			engineRPC := &forkchoiceTestEngineRPC{}
+			client := newForkchoiceTestClient(ethRPC, engineRPC)
+
+			err := client.SetSafe(t.Context(), common.HexToHash("0x1234"))
+			require.Error(t, err)
+			require.Empty(t, engineRPC.forkchoiceStates())
+			require.False(t, client.forkchoiceInitialized)
+		})
+	}
+}
+
+func TestInitChainMarksGenesisForkchoiceInitialized(t *testing.T) {
+	genesis := forkchoiceTestHeader(0, 1)
+	ethRPC := newForkchoiceTestEthRPC(genesis, nil, nil)
+	ethRPC.headers[0] = genesis
+	engineRPC := &forkchoiceTestEngineRPC{}
+	client := newForkchoiceTestClient(ethRPC, engineRPC)
+	client.genesisHash = genesis.Hash()
+
+	_, err := client.InitChain(t.Context(), time.Unix(0, 0), 1, "test")
+	require.NoError(t, err)
+	require.True(t, client.forkchoiceInitialized)
+
+	states := engineRPC.forkchoiceStates()
+	require.Len(t, states, 1)
+	require.Equal(t, genesis.Hash(), states[0].HeadBlockHash)
+	require.Equal(t, genesis.Hash(), states[0].SafeBlockHash)
+	require.Equal(t, genesis.Hash(), states[0].FinalizedBlockHash)
+}
+
+func forkchoiceTestHeader(height uint64, marker byte) *types.Header {
+	return &types.Header{
+		Number:   new(big.Int).SetUint64(height),
+		Root:     common.BytesToHash([]byte{marker, 0xaa}),
+		GasLimit: 30_000_000,
+		Time:     1_700_000_000 + height,
+		Extra:    []byte{marker},
+	}
+}
+
+type forkchoiceTestEthRPC struct {
+	mu       sync.Mutex
+	headers  map[int64]*types.Header
+	failures map[int64]int
+	calls    map[int64]int
+}
+
+func newForkchoiceTestEthRPC(head, safe, finalized *types.Header) *forkchoiceTestEthRPC {
+	return &forkchoiceTestEthRPC{
+		headers: map[int64]*types.Header{
+			rpc.LatestBlockNumber.Int64():    head,
+			rpc.SafeBlockNumber.Int64():      safe,
+			rpc.FinalizedBlockNumber.Int64(): finalized,
+		},
+		failures: make(map[int64]int),
+		calls:    make(map[int64]int),
+	}
+}
+
+func (m *forkchoiceTestEthRPC) HeaderByNumber(_ context.Context, number *big.Int) (*types.Header, error) {
+	key := number.Int64()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls[key]++
+	if m.failures[key] > 0 {
+		m.failures[key]--
+		return nil, errors.New("temporary header failure")
+	}
+	header := m.headers[key]
+	if header == nil {
+		return nil, errors.New("header not found")
+	}
+	return header, nil
+}
+
+func (*forkchoiceTestEthRPC) GetTxs(context.Context) ([]string, error) { return nil, nil }
+
+func (*forkchoiceTestEthRPC) GetNextProposer(context.Context, *big.Int) (common.Hash, error) {
+	return common.Hash{}, nil
+}
+
+func (m *forkchoiceTestEthRPC) callsFor(key int64) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.calls[key]
+}
+
+func (m *forkchoiceTestEthRPC) totalCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	total := 0
+	for _, calls := range m.calls {
+		total += calls
+	}
+	return total
+}
+
+type forkchoiceTestEngineRPC struct {
+	mu      sync.Mutex
+	states  []engine.ForkchoiceStateV1
+	payload *EnginePayloadEnvelope
+}
+
+func (m *forkchoiceTestEngineRPC) ForkchoiceUpdated(_ context.Context, state engine.ForkchoiceStateV1, attrs map[string]any) (*engine.ForkChoiceResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.states = append(m.states, state)
+	response := &engine.ForkChoiceResponse{PayloadStatus: engine.PayloadStatusV1{Status: engine.VALID}}
+	if attrs != nil {
+		payloadID := engine.PayloadID{1}
+		response.PayloadID = &payloadID
+	}
+	return response, nil
+}
+
+func (m *forkchoiceTestEngineRPC) GetPayload(context.Context, engine.PayloadID) (*EnginePayloadEnvelope, error) {
+	if m.payload == nil {
+		return nil, errors.New("payload not configured")
+	}
+	return m.payload, nil
+}
+
+func (*forkchoiceTestEngineRPC) NewPayload(context.Context, *EnginePayloadEnvelope, []string, string, [][]byte) (*engine.PayloadStatusV1, error) {
+	return &engine.PayloadStatusV1{Status: engine.VALID}, nil
+}
+
+func (m *forkchoiceTestEngineRPC) forkchoiceStates() []engine.ForkchoiceStateV1 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]engine.ForkchoiceStateV1(nil), m.states...)
+}
+
+func newForkchoiceTestClient(ethRPC EthRPCClient, engineRPC EngineRPCClient) *EngineClient {
+	return &EngineClient{
+		ethClient:                 ethRPC,
+		engineClient:              engineRPC,
+		store:                     NewEVMStore(dssync.MutexWrap(ds.NewMapDatastore())),
+		currentHeadBlockHash:      common.HexToHash("0x01"),
+		currentSafeBlockHash:      common.HexToHash("0x01"),
+		currentFinalizedBlockHash: common.HexToHash("0x01"),
+		blockHashCache:            make(map[uint64]common.Hash),
+		logger:                    zerolog.Nop(),
+	}
+}

--- a/execution/evm/proposer_test.go
+++ b/execution/evm/proposer_test.go
@@ -102,6 +102,7 @@ func TestExecuteTxsReturnsNextProposerWhenChanged(t *testing.T) {
 		store:                     store,
 		currentSafeBlockHash:      common.HexToHash("0x10"),
 		currentFinalizedBlockHash: common.HexToHash("0x10"),
+		forkchoiceInitialized:     true,
 		logger:                    zerolog.Nop(),
 	}
 


### PR DESCRIPTION
The EVM execution client initialized head, safe, and finalized hashes to genesis after an ev-node restart. Its first forkchoice update could therefore regress the execution layer's persisted safe and finalized state.

Restore all three forkchoice hashes from the execution layer's `latest`, `safe`, and `finalized` block tags before any operation that can issue a forkchoice update. Initialization is serialized, retryable after RPC failures, validates `finalized <= safe <= head`, and seeds the height-to-hash cache. Fresh chains are marked initialized after the genesis forkchoice update.

Fixes #2402.

Validation:
- `go test ./...` in `execution/evm`
- focused forkchoice initialization tests with `-race`
- `just test-evm`
- `TestEvmSequencerFullNodeRestartE2E`, including `StandardRestart` and `LazyModeRestart`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved forkchoice state recovery when reconnecting to the execution layer.
  - Restored head, safe, and finalized block information before processing operations.
  - Added validation to prevent updates when recovered block relationships or headers are inconsistent.
  - Ensured initialization is safe under concurrent requests and can be retried after a failed recovery.
  - Preserved correct genesis-state handling for newly initialized chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->